### PR TITLE
fix: benchmark timing broken on macOS

### DIFF
--- a/deepclaude.sh
+++ b/deepclaude.sh
@@ -179,12 +179,14 @@ run_benchmark() {
             fireworks)  url="$FIREWORKS_URL"; key="${FIREWORKS_API_KEY:-}"; model="accounts/fireworks/models/deepseek-v4-pro" ;;
         esac
         if [[ -z "$key" ]]; then echo "  $name: SKIP (no key)"; continue; fi
-        local start_ms=$(date +%s%3N 2>/dev/null || python3 -c 'import time;print(int(time.time()*1000))')
+        local start_ms
+        start_ms=$(python3 -c 'import time;print(int(time.time()*1000))' 2>/dev/null || date +%s)000
         local status=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$url/v1/messages" \
             -H "x-api-key: $key" -H "content-type: application/json" -H "anthropic-version: 2023-06-01" \
             -d "{\"model\":\"$model\",\"max_tokens\":32,\"messages\":[{\"role\":\"user\",\"content\":\"Reply: ok\"}]}" \
             --max-time 30 2>/dev/null || echo "timeout")
-        local end_ms=$(date +%s%3N 2>/dev/null || python3 -c 'import time;print(int(time.time()*1000))')
+        local end_ms
+        end_ms=$(python3 -c 'import time;print(int(time.time()*1000))' 2>/dev/null || date +%s)000
         local elapsed=$((end_ms - start_ms))
         if [[ "$status" == "200" ]]; then
             echo "  $name: OK (${elapsed}ms)"


### PR DESCRIPTION
## Summary
- Replaces `date +%s%3N` with `python3 -c 'import time;print(int(time.time()*1000))'` as the primary timing method in `run_benchmark()`

## Problem
`date +%s%3N` is a GNU coreutils extension. macOS ships BSD date, which does not support `%N`. Crucially, BSD date **does not fail** — it outputs garbage like `1714841232%3N` (literal `%3N`), so the `|| python3 ...` fallback **never triggers**. The subsequent `$((end_ms - start_ms))` arithmetic either produces wrong results or errors under `set -e`.

## Test plan
- [ ] On macOS: run `./deepclaude.sh --benchmark` → should show reasonable ms timings
- [ ] On Linux: run `./deepclaude.sh --benchmark` → should still work (python3 is widely available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)