### PR TITLE
fix: add request body size limit to proxy

### DIFF
--- a/proxy/model-proxy.js
+++ b/proxy/model-proxy.js
@@ -6,6 +6,7 @@ import { Transform } from 'stream';
 const ANTHROPIC_FALLBACK = 'https://api.anthropic.com';
 const MODEL_PATHS = ['/v1/messages'];
 const REQUEST_TIMEOUT_MS = 5 * 60 * 1000; // 5 min per request
+const MAX_BODY_SIZE = 50 * 1024 * 1024; // 50 MB
 
 const PRICING_PER_M = {
     deepseek:   { input: 0.44,  output: 0.87 },
@@ -274,8 +275,20 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
             }
 
             const chunks = [];
-            clientReq.on('data', c => chunks.push(c));
+            let bodySize = 0;
+            clientReq.on('data', c => {
+                bodySize += c.length;
+                if (bodySize > MAX_BODY_SIZE) {
+                    console.error(`[MODEL-PROXY] #${reqCount} BODY_TOO_LARGE (${bodySize} bytes)`);
+                    clientRes.writeHead(413, { 'content-type': 'application/json' });
+                    clientRes.end(JSON.stringify({ error: { message: 'Request body too large' } }));
+                    clientReq.destroy();
+                    return;
+                }
+                chunks.push(c);
+            });
             clientReq.on('end', () => {
+                if (bodySize > MAX_BODY_SIZE) return;
                 const body = Buffer.concat(chunks);
                 const opts = {
                     hostname: dest.hostname,


### PR DESCRIPTION
## Summary
- Adds a 50MB request body size limit to the model API proxy path in `proxy/model-proxy.js`
- Returns HTTP 413 and destroys the connection when the limit is exceeded

## Problem
The `/_proxy/mode` control endpoint already had a 1KB body size limit, but the main model API request path (`/v1/messages`) collected request body chunks into memory without any bound. A client (or a bug in the calling code) could send an arbitrarily large request body, causing the proxy Node.js process to consume unbounded memory and potentially crash.

## Test plan
- [ ] Normal usage still works: send a regular `/v1/messages` request through the proxy
- [ ] Oversized request is rejected: send a >50MB body and verify 413 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)