### PR TITLE
fix: PowerShell env var cleanup on Ctrl+C/crash

### DIFF
--- a/deepclaude.ps1
+++ b/deepclaude.ps1
@@ -247,10 +247,12 @@ $env:CLAUDE_CODE_SUBAGENT_MODEL = $p.subagent
 $env:CLAUDE_CODE_EFFORT_LEVEL = "max"
 Remove-Item Env:ANTHROPIC_API_KEY -ErrorAction SilentlyContinue
 
-& claude @Args
-
-foreach ($v in @("ANTHROPIC_BASE_URL","ANTHROPIC_AUTH_TOKEN","ANTHROPIC_MODEL",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL","ANTHROPIC_DEFAULT_SONNET_MODEL",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL","CLAUDE_CODE_SUBAGENT_MODEL","CLAUDE_CODE_EFFORT_LEVEL")) {
-    Remove-Item "Env:$v" -ErrorAction SilentlyContinue
+try {
+    & claude @Args
+} finally {
+    foreach ($v in @("ANTHROPIC_BASE_URL","ANTHROPIC_AUTH_TOKEN","ANTHROPIC_MODEL",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL","ANTHROPIC_DEFAULT_SONNET_MODEL",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL","CLAUDE_CODE_SUBAGENT_MODEL","CLAUDE_CODE_EFFORT_LEVEL")) {
+        Remove-Item "Env:$v" -ErrorAction SilentlyContinue
+    }
 }


### PR DESCRIPTION
## Summary
- Wraps the regular launch path in `try/finally` to ensure env var cleanup always runs

## Problem
The remote mode already used `try/finally` for env cleanup, but the regular launch mode did not. If the user presses Ctrl+C or `claude` crashes, the cleanup code after `& claude @Args` is skipped. This leaks sensitive env vars into the parent shell session, including `ANTHROPIC_AUTH_TOKEN` which contains the API key.

## Test plan
- [ ] Launch with `deepclaude.ps1 -b ds`, then Ctrl+C → env vars should be cleaned up
- [ ] Normal exit still works and cleans up

🤖 Generated with [Claude Code](https://claude.com/claude-code)