### PR TITLE
fix: route default launch through proxy (fixes cost tracking and auth override)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+buy_me_a_coffee: zoops

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,15 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: # Replace with a single Open Collective username
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cloud-foundry
+polar: # Replace with a single Polar username
 buy_me_a_coffee: zoops
+thanks_dev: # Replace with a single thanks.dev username
+custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Claude Code reads these environment variables to determine where to send API cal
 | Variable | What it does |
 |---|---|
 | `ANTHROPIC_BASE_URL` | API endpoint (default: api.anthropic.com) |
-| `ANTHROPIC_AUTH_TOKEN` | API key for the backend |
+| `ANTHROPIC_API_KEY` | API key for the backend |
 | `ANTHROPIC_DEFAULT_OPUS_MODEL` | Model name for Opus-tier tasks |
 | `ANTHROPIC_DEFAULT_SONNET_MODEL` | Model name for Sonnet-tier tasks |
 | `ANTHROPIC_DEFAULT_HAIKU_MODEL` | Model name for Haiku-tier (subagents) |
@@ -86,7 +86,7 @@ Claude Code reads these environment variables to determine where to send API cal
 
 | Backend | Flag | Input/M | Output/M | Servers | Notes |
 |---|---|---|---|---|---|
-| **DeepSeek** (default) | `--backend ds` | $0.44 | $0.87 | China | Auto context caching (120x cheaper on repeat turns) |
+| **DeepSeek** (default) | `--backend ds` | $0.44 | $0.87 | China | Auto context caching (110x cheaper on repeat turns) |
 | **OpenRouter** | `--backend or` | $0.44 | $0.87 | US | Cheapest, lowest latency from US/EU |
 | **Fireworks AI** | `--backend fw` | $1.74 | $3.48 | US | Fastest inference |
 | **Anthropic** | `--backend anthropic` | $3.00 | $15.00 | US | Original Claude Opus (for hard problems) |

--- a/deepclaude.ps1
+++ b/deepclaude.ps1
@@ -218,8 +218,8 @@ if ($Remote) {
 
 # --- Launch ---
 if ($Backend -eq "anthropic") {
-    foreach ($v in @("ANTHROPIC_BASE_URL","ANTHROPIC_AUTH_TOKEN","ANTHROPIC_DEFAULT_OPUS_MODEL",
-        "ANTHROPIC_DEFAULT_SONNET_MODEL","ANTHROPIC_DEFAULT_HAIKU_MODEL",
+    foreach ($v in @("ANTHROPIC_BASE_URL","ANTHROPIC_AUTH_TOKEN","ANTHROPIC_API_KEY",
+        "ANTHROPIC_DEFAULT_OPUS_MODEL","ANTHROPIC_DEFAULT_SONNET_MODEL","ANTHROPIC_DEFAULT_HAIKU_MODEL",
         "CLAUDE_CODE_SUBAGENT_MODEL","CLAUDE_CODE_EFFORT_LEVEL")) {
         Remove-Item "Env:$v" -ErrorAction SilentlyContinue
     }
@@ -232,25 +232,61 @@ $p = $Providers[$Backend]
 if (-not $p) { Write-Host "ERROR: Unknown backend '$Backend'. Use: ds, or, fw, anthropic" -ForegroundColor Red; exit 1 }
 if (-not $p.key) { Write-Host "ERROR: $($p.keyName) not set" -ForegroundColor Red; exit 1 }
 
-Write-Host "`n  Launching Claude Code via $($p.name)..." -ForegroundColor Cyan
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+Write-Host "`n  Starting model proxy for $($p.name)..." -ForegroundColor Cyan
 Write-Host "  Endpoint: $($p.url)" -ForegroundColor DarkGray
 Write-Host "  Model: $($p.opus) (main) + $($p.haiku) (subagents)" -ForegroundColor DarkGray
 Write-Host ""
 
-$env:ANTHROPIC_BASE_URL = $p.url
-$env:ANTHROPIC_AUTH_TOKEN = $p.key
-$env:ANTHROPIC_MODEL = $p.opus
+$proxyScript = Join-Path $ScriptDir "proxy\start-proxy.js"
+$proxyProc = Start-Process -FilePath "node" -ArgumentList $proxyScript,$p.url,$p.key -PassThru -WindowStyle Hidden -RedirectStandardOutput "$env:TEMP\deepclaude-proxy-port.txt"
+
+$tries = 0
+while ($tries -lt 30) {
+    Start-Sleep -Milliseconds 200
+    $tries++
+    if (Test-Path "$env:TEMP\deepclaude-proxy-port.txt") {
+        $content = Get-Content "$env:TEMP\deepclaude-proxy-port.txt" -ErrorAction SilentlyContinue
+        if ($content) { break }
+    }
+}
+
+$proxyPort = (Get-Content "$env:TEMP\deepclaude-proxy-port.txt" -ErrorAction SilentlyContinue | Select-Object -First 1)
+Remove-Item "$env:TEMP\deepclaude-proxy-port.txt" -ErrorAction SilentlyContinue
+
+if (-not $proxyPort) {
+    Write-Host "ERROR: Proxy failed to start" -ForegroundColor Red
+    if ($proxyProc -and -not $proxyProc.HasExited) { Stop-Process -Id $proxyProc.Id -Force }
+    exit 1
+}
+
+Write-Host "  Proxy on :$proxyPort -> $($p.url)" -ForegroundColor DarkGray
+Write-Host "  Cost tracking: curl http://127.0.0.1:$proxyPort/_proxy/cost" -ForegroundColor DarkGray
+Write-Host ""
+
+# Route Claude Code through the proxy so cost tracking and /switch work.
+# Proxy replaces auth in-flight — backend key is also set as ANTHROPIC_API_KEY
+# so Claude Code starts cleanly regardless of login state.
+$env:ANTHROPIC_BASE_URL = "http://127.0.0.1:$proxyPort"
+$env:ANTHROPIC_API_KEY = $p.key
 $env:ANTHROPIC_DEFAULT_OPUS_MODEL = $p.opus
 $env:ANTHROPIC_DEFAULT_SONNET_MODEL = $p.sonnet
 $env:ANTHROPIC_DEFAULT_HAIKU_MODEL = $p.haiku
 $env:CLAUDE_CODE_SUBAGENT_MODEL = $p.subagent
 $env:CLAUDE_CODE_EFFORT_LEVEL = "max"
-Remove-Item Env:ANTHROPIC_API_KEY -ErrorAction SilentlyContinue
+Remove-Item Env:ANTHROPIC_AUTH_TOKEN -ErrorAction SilentlyContinue
 
-& claude @Args
-
-foreach ($v in @("ANTHROPIC_BASE_URL","ANTHROPIC_AUTH_TOKEN","ANTHROPIC_MODEL",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL","ANTHROPIC_DEFAULT_SONNET_MODEL",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL","CLAUDE_CODE_SUBAGENT_MODEL","CLAUDE_CODE_EFFORT_LEVEL")) {
-    Remove-Item "Env:$v" -ErrorAction SilentlyContinue
+try {
+    & claude @Args
+} finally {
+    if ($proxyProc -and -not $proxyProc.HasExited) {
+        Stop-Process -Id $proxyProc.Id -Force -ErrorAction SilentlyContinue
+        Write-Host "  Proxy stopped." -ForegroundColor DarkGray
+    }
+    foreach ($v in @("ANTHROPIC_BASE_URL","ANTHROPIC_API_KEY","ANTHROPIC_DEFAULT_OPUS_MODEL",
+        "ANTHROPIC_DEFAULT_SONNET_MODEL","ANTHROPIC_DEFAULT_HAIKU_MODEL",
+        "CLAUDE_CODE_SUBAGENT_MODEL","CLAUDE_CODE_EFFORT_LEVEL")) {
+        Remove-Item "Env:$v" -ErrorAction SilentlyContinue
+    }
 }

--- a/deepclaude.sh
+++ b/deepclaude.sh
@@ -198,7 +198,7 @@ run_benchmark() {
 launch_claude() {
     if [[ "$BACKEND" == "anthropic" ]]; then
         echo "  Launching Claude Code (normal Anthropic backend)..."
-        unset ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN
+        unset ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY
         unset ANTHROPIC_DEFAULT_OPUS_MODEL ANTHROPIC_DEFAULT_SONNET_MODEL
         unset ANTHROPIC_DEFAULT_HAIKU_MODEL CLAUDE_CODE_SUBAGENT_MODEL
         unset CLAUDE_CODE_EFFORT_LEVEL
@@ -207,17 +207,44 @@ launch_claude() {
 
     resolve_backend
 
-    echo "  Launching Claude Code via $BACKEND..."
+    echo "  Starting model proxy for $BACKEND..."
     echo "  Endpoint: $RESOLVED_URL"
     echo "  Model: $RESOLVED_OPUS (main) + $RESOLVED_HAIKU (subagents)"
     echo ""
 
-    export ANTHROPIC_BASE_URL="$RESOLVED_URL"
-    export ANTHROPIC_AUTH_TOKEN="$RESOLVED_KEY"
-    set_model_env
-    unset ANTHROPIC_API_KEY
+    local port_file
+    port_file=$(mktemp)
+    node "$SCRIPT_DIR/proxy/start-proxy.js" "$RESOLVED_URL" "$RESOLVED_KEY" > "$port_file" &
+    PROXY_PID=$!
 
-    exec claude "$@"
+    local tries=0
+    while [[ ! -s "$port_file" ]] && [[ $tries -lt 30 ]]; do
+        sleep 0.2
+        tries=$((tries + 1))
+    done
+
+    if [[ ! -s "$port_file" ]]; then
+        echo "ERROR: Proxy failed to start" >&2
+        rm -f "$port_file"
+        exit 1
+    fi
+
+    local proxy_port
+    proxy_port=$(head -1 "$port_file")
+    rm -f "$port_file"
+
+    echo "  Proxy on :$proxy_port -> $RESOLVED_URL"
+    echo "  Cost tracking: curl http://127.0.0.1:$proxy_port/_proxy/cost"
+    echo ""
+
+    export ANTHROPIC_BASE_URL="http://127.0.0.1:$proxy_port"
+    # Set the backend key as ANTHROPIC_API_KEY — proxy replaces it in-flight with
+    # the correct auth for the upstream, so subscription OAuth tokens are also handled.
+    export ANTHROPIC_API_KEY="$RESOLVED_KEY"
+    unset ANTHROPIC_AUTH_TOKEN
+    set_model_env
+
+    claude "$@"
 }
 
 launch_remote() {


### PR DESCRIPTION
## Summary

- `deepclaude` (default mode) previously set `ANTHROPIC_BASE_URL` directly to the upstream backend, bypassing the local proxy entirely
- The proxy on `:3200` was only ever started in `--remote` mode — so `/_proxy/cost` always showed `{"backends":{}, "total_cost":0}` and `/switch` had no effect in normal sessions
- If the user was logged in via `claude login` (Claude Max/Pro subscription), the OAuth token wasn't intercepted, causing requests to fall back to Anthropic

Both `deepclaude.sh` and `deepclaude.ps1` now start the proxy on a dynamic port and point `ANTHROPIC_BASE_URL` at it in all non-anthropic modes. The proxy already replaces auth headers in-flight for model calls, so subscription OAuth tokens and API keys are both handled correctly. `ANTHROPIC_API_KEY` is set to the backend key so Claude Code starts cleanly regardless of login state.

Closes #3

## Test plan

- [ ] `deepclaude` (no flags) — verify startup shows `Proxy on :XXXX` and `Cost tracking: curl …`
- [ ] After a few turns, `curl http://127.0.0.1:PORT/_proxy/cost` shows non-zero tokens/cost
- [ ] `deepclaude --switch ds` still works (proxy is in path)
- [ ] `deepclaude --backend anthropic` still launches without proxy
- [ ] `deepclaude --remote` still works unchanged

https://claude.ai/code/session_01FTqposuxzUQwueS9Zpa3ez

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTqposuxzUQwueS9Zpa3ez)_