### PR TITLE
fix(security): tighten /_proxy/mode origin check (CSRF / DNS rebinding)

### DIFF
--- a/proxy/model-proxy.js
+++ b/proxy/model-proxy.js
@@ -7,6 +7,11 @@ const ANTHROPIC_FALLBACK = 'https://api.anthropic.com';
 const MODEL_PATHS = ['/v1/messages'];
 const REQUEST_TIMEOUT_MS = 5 * 60 * 1000; // 5 min per request
 
+// Strict allowlist for the Origin header on /_proxy/mode. Must match the
+// loopback host exactly (with optional port) — a prefix check would let
+// http://localhost.attacker.com:3200 through and enable DNS-rebinding CSRF.
+const LOCAL_ORIGIN_RE = /^http:\/\/(?:127\.0\.0\.1|localhost|\[::1\])(?::\d{1,5})?$/i;
+
 const MODEL_REMAP = {
     deepseek: {
         'claude-opus-4-6':    'deepseek-v4-pro',
@@ -228,7 +233,7 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
                 }
                 if (urlPath === '/_proxy/mode' && clientReq.method === 'POST') {
                     const origin = clientReq.headers['origin'] || '';
-                    if (origin && !origin.startsWith('http://127.0.0.1') && !origin.startsWith('http://localhost')) {
+                    if (origin && !LOCAL_ORIGIN_RE.test(origin)) {
                         clientRes.writeHead(403, { 'content-type': 'application/json' });
                         clientRes.end(JSON.stringify({ error: 'Forbidden' }));
                         return;


### PR DESCRIPTION
## Summary

`proxy/model-proxy.js` exposes a control endpoint at `POST /_proxy/mode` that swaps the local proxy's active backend (DeepSeek / OpenRouter / Fireworks / Anthropic). The CSRF defense is an Origin-header allowlist:

```js
const origin = clientReq.headers['origin'] || '';
if (origin && !origin.startsWith('http://127.0.0.1') && !origin.startsWith('http://localhost')) {
    clientRes.writeHead(403, { 'content-type': 'application/json' });
    ...
}
```

`String.prototype.startsWith` has no boundary, so `http://localhost.attacker.com:3200` and `http://127.0.0.1.attacker.com:3200` both pass the check. Combined with DNS rebinding — attacker registers a domain like `localhost.attacker.com`, hosts the page on port 3200, then re-points the A record to 127.0.0.1 — a victim browsing the attacker page can `fetch('/_proxy/mode', {method:'POST', body:'backend=...'})` and silently switch the user's active backend.

## Impact

- **Silent prompt redirection.** The proxy attaches the user's stored API key for the active backend before forwarding `/v1/messages`. After a forced switch, prompts the user composes against (e.g.) Anthropic are sent to DeepSeek with valid auth — proprietary code, secrets in scrollback, and conversation context follow.
- **Cost asymmetry.** Forcing a victim from DeepSeek to Anthropic is a 17× output-token bill spike (the README's headline number, in reverse).
- No attacker creds required — they flip whichever backend the user already configured.

## Location

`proxy/model-proxy.js:230-235` (against `main` @ 70518b6).

## Fix

Replace the prefix check with a strict regex anchored to the loopback host with optional port:

```js
const LOCAL_ORIGIN_RE = /^http:\/\/(?:127\.0\.0\.1|localhost|\[::1\])(?::\d{1,5})?$/i;
...
if (origin && !LOCAL_ORIGIN_RE.test(origin)) { ... }
```

Curl/CLI usage (no Origin header) continues to work, matching the documented usage in the README.

## Verification

End-to-end against a local instance of `startModelProxy` on port 13200:

| Origin header | Before patch | After patch |
|---|---|---|
| (none — curl) | 200, switch | 200, switch |
| `http://localhost:13200` | 200, switch | 200, switch |
| `http://127.0.0.1` | 200, switch | 200, switch |
| `http://localhost.attacker.com:13200` | **200, switch** | **403** |
| `http://127.0.0.1.attacker.com:13200` | **200, switch** | **403** |
| `http://attacker.com` | 403 | 403 |

Preserves all legitimate paths (curl, slash-command flow, VS Code task POSTs from loopback) and closes both DNS-rebinding bypass shapes.

## Detected by

Aeon (manual review of `proxy/model-proxy.js` after Semgrep / TruffleHog / OSV came back clean).
- Severity: medium
- CWE-352 (CSRF) + CWE-350 (reverse-DNS reliance)

---
Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron). Close it if you'd rather fix this differently.
