### PR TITLE
fix(proxy): missing proxyRes error handler + SSE corruption on error after headers

### DIFF
--- a/proxy/model-proxy.js
+++ b/proxy/model-proxy.js
@@ -368,6 +368,20 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
                         console.log(`[MODEL-PROXY] #${reqId} TTFB ${ttfb}ms (status ${proxyRes.statusCode})`);
                     }
 
+                    // Without this, an upstream stream error (connection reset
+                    // mid-response) emits an unhandled 'error' on proxyRes and
+                    // crashes the proxy process.
+                    proxyRes.on('error', (err) => {
+                        const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
+                        console.error(`[MODEL-PROXY] #${reqId} upstream stream error after ${elapsed}s: ${err.message}`);
+                        if (!clientRes.headersSent) {
+                            clientRes.writeHead(502, { 'content-type': 'application/json' });
+                            clientRes.end(JSON.stringify({ error: { message: 'Upstream stream error' } }));
+                        } else {
+                            clientRes.destroy(err);
+                        }
+                    });
+
                     const ct = proxyRes.headers['content-type'] || '';
                     const isSSE = ct.includes('text/event-stream');
 
@@ -415,8 +429,14 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
                     console.error(`[MODEL-PROXY] #${reqId} ERROR after ${elapsed}s: ${err.message}`);
                     if (!clientRes.headersSent) {
                         clientRes.writeHead(502, { 'content-type': 'application/json' });
+                        clientRes.end(JSON.stringify({ error: { message: 'Upstream connection error' } }));
+                    } else {
+                        // Headers already sent (likely mid-SSE) — emitting JSON
+                        // here would inject a non-event into the event-stream and
+                        // break the client parser. Terminate the response so the
+                        // client sees a clean transport error instead.
+                        clientRes.destroy(err);
                     }
-                    clientRes.end(JSON.stringify({ error: { message: 'Upstream connection error' } }));
                 });
 
                 proxyReq.end(body);


### PR DESCRIPTION
## Summary

Two production bugs in `proxy/model-proxy.js` surfaced by an audit run against `aattaran/Jarvis2` (shared proxy ancestry — both fixes apply verbatim).

### Bug 1 — missing `proxyRes` error handler (process crash)

The three response paths inside the `httpsRequest` callback —

- `proxyRes.pipe(norm).pipe(clientRes)` (SSE)
- the `data`/`end` JSON collector
- the passthrough `proxyRes.pipe(clientRes)`

— never attach an `'error'` handler to `proxyRes`. If the upstream connection drops mid-response (TCP RST, TLS abort, server crash), Node emits an unhandled `'error'` on the response stream and **the entire proxy process exits**, killing every concurrent in-flight Claude Code session.

**Fix:** attach a single `proxyRes.on('error', ...)` immediately after the response is opened, before any of the branch-specific piping. Mirrors the existing `proxyReq.on('error')` shape: 502+JSON if headers haven't gone out, otherwise destroy the response.

### Bug 2 — SSE corruption when `proxyReq` errors after headers sent

Current `proxyReq.on('error')` unconditionally calls:

```js
clientRes.end(JSON.stringify({ error: { message: 'Upstream connection error' } }));
```

If headers already went out as `text/event-stream` (the common SSE case for `/v1/messages`), that JSON gets injected mid-stream. Claude Code's SSE parser then sees a non-event payload and either silently truncates the assistant turn or throws — depending on where in the stream the upstream died.

**Fix:** `clientRes.destroy(err)` once `clientRes.headersSent` is true, so the client sees a clean transport-level abort instead of a corrupted event stream.

## Files

- `proxy/model-proxy.js` — added `proxyRes` error handler; gated `proxyReq` error handler's `end()` on `!headersSent`.

## Note on the third audit finding

The same audit also flagged the `/_proxy/mode` Origin-prefix CSRF/DNS-rebinding issue. That's already covered by [PR #16](https://github.com/aattaran/deepclaude/pull/16) (open, from `aaronjmars`), so it is intentionally **not** in this PR.

## Test plan

- [ ] Local repro: kill upstream mid-SSE (`iptables -A OUTPUT -p tcp --dport 443 -j REJECT` after first chunk) → before patch: process crashes / SSE garbage; after patch: clean client error, proxy survives.
- [ ] Existing happy path unchanged: streaming + JSON `/v1/messages` still flow through `UsageNormalizer` and produce correct `/_proxy/cost`.
- [ ] `/_proxy/status`, `/_proxy/mode`, `/_proxy/cost` still respond correctly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NWm8R6w2mGxoMgFQRLRgKT)_