### PR TITLE
feat: --auto option, unlock auto/bypassPermissions permission modes via canonical claude-* model names

### DIFF
--- a/deepclaude.sh
+++ b/deepclaude.sh
@@ -25,6 +25,7 @@ BACKEND="${CHEAPCLAUDE_DEFAULT_BACKEND:-ds}"
 ACTION="launch"
 SWITCH_BACKEND=""
 PROXY_PID=""
+AUTO_MODE=0
 
 # --- Parse args ---
 while [[ $# -gt 0 ]]; do
@@ -32,6 +33,7 @@ while [[ $# -gt 0 ]]; do
         --backend|-b) BACKEND="$2"; shift 2 ;;
         --switch|-s)  ACTION="switch"; SWITCH_BACKEND="$2"; shift 2 ;;
         --remote|-r)  ACTION="remote"; shift ;;
+        --auto)       AUTO_MODE=1; shift ;;
         --status)     ACTION="status"; shift ;;
         --cost)       ACTION="cost"; shift ;;
         --benchmark)  ACTION="benchmark"; shift ;;
@@ -88,16 +90,25 @@ resolve_backend() {
 }
 
 set_model_env() {
-    # Use canonical Claude model names so Claude Code's permission gate
-    # (auto / bypassPermissions) treats the session as a Claude session.
-    # The local proxy translates these names back to backend-specific names
-    # on the wire via MODEL_REMAP in proxy/model-proxy.js.
-    # IMPORTANT: these names must remain keys in every MODEL_REMAP backend
-    # block, otherwise unmapped requests will 404 against the backend.
-    export ANTHROPIC_DEFAULT_OPUS_MODEL="claude-opus-4-7"
-    export ANTHROPIC_DEFAULT_SONNET_MODEL="claude-sonnet-4-6"
-    export ANTHROPIC_DEFAULT_HAIKU_MODEL="claude-haiku-4-5-20251001"
-    export CLAUDE_CODE_SUBAGENT_MODEL="claude-haiku-4-5-20251001"
+    if [[ "$AUTO_MODE" == "1" ]]; then
+        # Canonical Claude model names so Claude Code's permission gate
+        # (auto / bypassPermissions) treats the session as a Claude session.
+        # The local proxy translates these names back to backend-specific
+        # names on the wire via MODEL_REMAP in proxy/model-proxy.js.
+        # IMPORTANT: these names must remain keys in every MODEL_REMAP
+        # backend block, otherwise unmapped requests will 404.
+        export ANTHROPIC_DEFAULT_OPUS_MODEL="claude-opus-4-7"
+        export ANTHROPIC_DEFAULT_SONNET_MODEL="claude-sonnet-4-6"
+        export ANTHROPIC_DEFAULT_HAIKU_MODEL="claude-haiku-4-5-20251001"
+        export CLAUDE_CODE_SUBAGENT_MODEL="claude-haiku-4-5-20251001"
+    else
+        # Backend names visible in the TUI; auto/bypassPermissions disabled
+        # because Claude Code's gate only unlocks for claude-* model names.
+        export ANTHROPIC_DEFAULT_OPUS_MODEL="$RESOLVED_OPUS"
+        export ANTHROPIC_DEFAULT_SONNET_MODEL="$RESOLVED_SONNET"
+        export ANTHROPIC_DEFAULT_HAIKU_MODEL="$RESOLVED_HAIKU"
+        export CLAUDE_CODE_SUBAGENT_MODEL="$RESOLVED_SUBAGENT"
+    fi
     export CLAUDE_CODE_EFFORT_LEVEL="max"
 }
 
@@ -219,6 +230,8 @@ show_help() {
     echo "Options:"
     echo "  -b, --backend <ds|or|fw|anthropic>  Backend (default: ds)"
     echo "  -r, --remote                        Remote control mode (browser URL)"
+    echo "  --auto                               Unlock auto/bypassPermissions modes"
+    echo "                                       (TUI shows claude-* names instead of backend names)"
     echo "  --status                             Show keys and backends"
     echo "  --cost                               Pricing comparison"
     echo "  --benchmark                          Latency test"
@@ -276,6 +289,17 @@ run_benchmark() {
     echo ""
 }
 
+print_auto_mode_tip() {
+    if [[ "$AUTO_MODE" == "1" ]]; then
+        echo "  Auto mode: ON (TUI will show 'claude-opus-4-7'; shift+tab cycles modes)"
+    else
+        local backend_long
+        backend_long=$(backend_long_name "$BACKEND") || backend_long="$BACKEND"
+        echo "  Auto mode: OFF (running $backend_long; TUI will show '$RESOLVED_OPUS')"
+        echo "  Tip: pass --auto to enable auto mode — TUI will show 'claude-opus-4-7' instead"
+    fi
+}
+
 # Run claude and surface the tail of $PROXY_LOG if it exits abnormally.
 # Skips signal-induced exits (>=128, e.g. 130 SIGINT, 143 SIGTERM) so
 # Ctrl+C doesn't dump a noisy log on intentional quit.
@@ -312,6 +336,7 @@ launch_claude() {
     echo "  Launching Claude Code via $BACKEND..."
     echo "  Proxy on :$PROXY_PORT -> $RESOLVED_URL"
     echo "  Model: $RESOLVED_OPUS (main) + $RESOLVED_HAIKU (subagents)"
+    print_auto_mode_tip
     echo ""
 
     # Route through local proxy so the model name remap fires and Claude Code
@@ -343,6 +368,7 @@ launch_remote() {
 
     echo "  Proxy on :$PROXY_PORT -> $RESOLVED_URL"
     echo "  Launching remote control via $BACKEND..."
+    print_auto_mode_tip
     echo ""
 
     export ANTHROPIC_BASE_URL="http://127.0.0.1:$PROXY_PORT"

--- a/deepclaude.sh
+++ b/deepclaude.sh
@@ -266,6 +266,20 @@ run_benchmark() {
     echo ""
 }
 
+# Run claude and surface the tail of $PROXY_LOG if it exits abnormally.
+# Skips signal-induced exits (>=128, e.g. 130 SIGINT, 143 SIGTERM) so
+# Ctrl+C doesn't dump a noisy log on intentional quit.
+run_claude_with_log_tail() {
+    local exit_code=0
+    "$@" || exit_code=$?
+    if [[ $exit_code -ne 0 && $exit_code -lt 128 ]]; then
+        echo "" >&2
+        echo "  claude exited with status $exit_code. Last 20 lines of $PROXY_LOG:" >&2
+        tail -20 "$PROXY_LOG" >&2 2>/dev/null || true
+    fi
+    return $exit_code
+}
+
 launch_claude() {
     if [[ "$BACKEND" == "anthropic" ]]; then
         echo "  Launching Claude Code (normal Anthropic backend)..."
@@ -298,7 +312,7 @@ launch_claude() {
     unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
 
     # Don't exec — we want the EXIT trap to clean up the proxy.
-    claude "$@"
+    run_claude_with_log_tail claude "$@"
 }
 
 launch_remote() {
@@ -325,7 +339,7 @@ launch_remote() {
     set_model_env
     unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
 
-    claude remote-control "$@"
+    run_claude_with_log_tail claude remote-control "$@"
 }
 
 # --- Main ---

--- a/deepclaude.sh
+++ b/deepclaude.sh
@@ -141,7 +141,11 @@ start_proxy() {
     local tries=0
     while [[ -z "$proxy_port" ]] && [[ $tries -lt 30 ]]; do
         if kill -0 "$PROXY_PID" 2>/dev/null; then
-            proxy_port=$(grep -E '^[0-9]+$' "$PROXY_LOG" 2>/dev/null | head -1)
+            # `|| true`: with `set -o pipefail`, grep returning no matches
+            # (exit 1) propagates as a pipeline failure that `set -e` exits
+            # on. We expect zero matches on early iterations before the
+            # proxy emits its port, so swallow the status here.
+            proxy_port=$(grep -E '^[0-9]+$' "$PROXY_LOG" 2>/dev/null | head -1 || true)
         else
             echo "ERROR: Proxy process died during startup" >&2
             echo "  Log: $PROXY_LOG" >&2

--- a/deepclaude.sh
+++ b/deepclaude.sh
@@ -109,15 +109,19 @@ backend_long_name() {
     esac
 }
 
-# Starts proxy/start-proxy.js in the background, waits for it to print its
-# port (a bare numeric line), sets the global PROXY_PID, and echoes the port
-# to stdout. Ongoing proxy logs go to PROXY_LOG (default /tmp/deepclaude-proxy.log).
+# Starts proxy/start-proxy.js in the background and waits for it to bind a
+# port. Sets PROXY_PID, PROXY_PORT, and PROXY_LOG as script globals so the
+# EXIT trap (cleanup_proxy) can see the pid. Must be called WITHOUT command
+# substitution — $(start_proxy) would run in a subshell and the globals
+# would never reach the parent.
+# PROXY_LOG defaults to /tmp/deepclaude-proxy.$$.log so concurrent invocations
+# don't truncate each other's logs; override with PROXY_LOG=<path>.
 # Requires: RESOLVED_URL, RESOLVED_KEY, BACKEND already set (call resolve_backend first).
 start_proxy() {
     local backend_long
     backend_long=$(backend_long_name "$BACKEND") || exit 1
 
-    PROXY_LOG="${PROXY_LOG:-/tmp/deepclaude-proxy.log}"
+    PROXY_LOG="${PROXY_LOG:-/tmp/deepclaude-proxy.$$.log}"
     : > "$PROXY_LOG"
     node "$SCRIPT_DIR/proxy/start-proxy.js" "$RESOLVED_URL" "$RESOLVED_KEY" "$backend_long" >> "$PROXY_LOG" 2>&1 &
     PROXY_PID=$!
@@ -147,7 +151,7 @@ start_proxy() {
         exit 1
     fi
 
-    echo "$proxy_port"
+    PROXY_PORT="$proxy_port"
 }
 
 show_status() {
@@ -273,17 +277,20 @@ launch_claude() {
     resolve_backend
 
     echo "  Starting model proxy for $BACKEND..."
-    local proxy_port
-    proxy_port=$(start_proxy)
+    # Call directly (not via $()): start_proxy sets PROXY_PID/PROXY_PORT/PROXY_LOG
+    # as script globals, which a subshell would never propagate to the parent
+    # — the EXIT trap needs PROXY_PID to actually clean up the node process.
+    start_proxy
+    echo "  Proxy log: $PROXY_LOG"
 
     echo "  Launching Claude Code via $BACKEND..."
-    echo "  Proxy on :$proxy_port -> $RESOLVED_URL"
+    echo "  Proxy on :$PROXY_PORT -> $RESOLVED_URL"
     echo "  Model: $RESOLVED_OPUS (main) + $RESOLVED_HAIKU (subagents)"
     echo ""
 
     # Route through local proxy so the model name remap fires and Claude Code
     # sees a Claude model (unlocking auto-mode and bypassPermissions).
-    export ANTHROPIC_BASE_URL="http://127.0.0.1:$proxy_port"
+    export ANTHROPIC_BASE_URL="http://127.0.0.1:$PROXY_PORT"
     set_model_env
     # Proxy injects auth itself; the client must not also send credentials.
     unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
@@ -305,14 +312,14 @@ launch_remote() {
     resolve_backend
 
     echo "  Starting model proxy for $BACKEND..."
-    local proxy_port
-    proxy_port=$(start_proxy)
+    start_proxy
+    echo "  Proxy log: $PROXY_LOG"
 
-    echo "  Proxy on :$proxy_port -> $RESOLVED_URL"
+    echo "  Proxy on :$PROXY_PORT -> $RESOLVED_URL"
     echo "  Launching remote control via $BACKEND..."
     echo ""
 
-    export ANTHROPIC_BASE_URL="http://127.0.0.1:$proxy_port"
+    export ANTHROPIC_BASE_URL="http://127.0.0.1:$PROXY_PORT"
     set_model_env
     unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
 

--- a/deepclaude.sh
+++ b/deepclaude.sh
@@ -92,6 +92,8 @@ set_model_env() {
     # (auto / bypassPermissions) treats the session as a Claude session.
     # The local proxy translates these names back to backend-specific names
     # on the wire via MODEL_REMAP in proxy/model-proxy.js.
+    # IMPORTANT: these names must remain keys in every MODEL_REMAP backend
+    # block, otherwise unmapped requests will 404 against the backend.
     export ANTHROPIC_DEFAULT_OPUS_MODEL="claude-opus-4-7"
     export ANTHROPIC_DEFAULT_SONNET_MODEL="claude-sonnet-4-6"
     export ANTHROPIC_DEFAULT_HAIKU_MODEL="claude-haiku-4-5-20251001"

--- a/deepclaude.sh
+++ b/deepclaude.sh
@@ -4,7 +4,17 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve SCRIPT_DIR through any symlink chain (e.g. /usr/local/bin/deepclaude
+# -> /path/to/repo/deepclaude.sh) so $SCRIPT_DIR/proxy/... works regardless of
+# how the script was invoked.
+_source="${BASH_SOURCE[0]}"
+while [ -L "$_source" ]; do
+    _dir="$(cd "$(dirname "$_source")" && pwd)"
+    _source="$(readlink "$_source")"
+    [[ "$_source" != /* ]] && _source="$_dir/$_source"
+done
+SCRIPT_DIR="$(cd "$(dirname "$_source")" && pwd)"
+unset _source _dir
 
 # --- Config ---
 DEEPSEEK_URL="https://api.deepseek.com/anthropic"
@@ -78,11 +88,66 @@ resolve_backend() {
 }
 
 set_model_env() {
-    export ANTHROPIC_DEFAULT_OPUS_MODEL="$RESOLVED_OPUS"
-    export ANTHROPIC_DEFAULT_SONNET_MODEL="$RESOLVED_SONNET"
-    export ANTHROPIC_DEFAULT_HAIKU_MODEL="$RESOLVED_HAIKU"
-    export CLAUDE_CODE_SUBAGENT_MODEL="$RESOLVED_SUBAGENT"
+    # Use canonical Claude model names so Claude Code's permission gate
+    # (auto / bypassPermissions) treats the session as a Claude session.
+    # The local proxy translates these names back to backend-specific names
+    # on the wire via MODEL_REMAP in proxy/model-proxy.js.
+    export ANTHROPIC_DEFAULT_OPUS_MODEL="claude-opus-4-7"
+    export ANTHROPIC_DEFAULT_SONNET_MODEL="claude-sonnet-4-6"
+    export ANTHROPIC_DEFAULT_HAIKU_MODEL="claude-haiku-4-5-20251001"
+    export CLAUDE_CODE_SUBAGENT_MODEL="claude-haiku-4-5-20251001"
     export CLAUDE_CODE_EFFORT_LEVEL="max"
+}
+
+backend_long_name() {
+    case "$1" in
+        ds|deepseek)   echo "deepseek" ;;
+        or|openrouter) echo "openrouter" ;;
+        fw|fireworks)  echo "fireworks" ;;
+        anthropic)     echo "anthropic" ;;
+        *) echo "ERROR: Unknown backend '$1'. Use: ds, or, fw, anthropic" >&2; return 1 ;;
+    esac
+}
+
+# Starts proxy/start-proxy.js in the background, waits for it to print its
+# port (a bare numeric line), sets the global PROXY_PID, and echoes the port
+# to stdout. Ongoing proxy logs go to PROXY_LOG (default /tmp/deepclaude-proxy.log).
+# Requires: RESOLVED_URL, RESOLVED_KEY, BACKEND already set (call resolve_backend first).
+start_proxy() {
+    local backend_long
+    backend_long=$(backend_long_name "$BACKEND") || exit 1
+
+    PROXY_LOG="${PROXY_LOG:-/tmp/deepclaude-proxy.log}"
+    : > "$PROXY_LOG"
+    node "$SCRIPT_DIR/proxy/start-proxy.js" "$RESOLVED_URL" "$RESOLVED_KEY" "$backend_long" >> "$PROXY_LOG" 2>&1 &
+    PROXY_PID=$!
+
+    # Wait for a line that is a bare integer (the port emitted by start-proxy.js
+    # after startModelProxy resolves). The proxy also writes a human-readable
+    # "[MODEL-PROXY] Listening on ..." banner first, so we can't just read line 1.
+    local proxy_port=""
+    local tries=0
+    while [[ -z "$proxy_port" ]] && [[ $tries -lt 30 ]]; do
+        if kill -0 "$PROXY_PID" 2>/dev/null; then
+            proxy_port=$(grep -E '^[0-9]+$' "$PROXY_LOG" 2>/dev/null | head -1)
+        else
+            echo "ERROR: Proxy process died during startup" >&2
+            echo "  Log: $PROXY_LOG" >&2
+            tail -20 "$PROXY_LOG" >&2 2>/dev/null
+            exit 1
+        fi
+        [[ -z "$proxy_port" ]] && sleep 0.2
+        tries=$((tries + 1))
+    done
+
+    if [[ -z "$proxy_port" ]]; then
+        echo "ERROR: Proxy failed to report a port within 6s" >&2
+        echo "  Log: $PROXY_LOG" >&2
+        tail -20 "$PROXY_LOG" >&2 2>/dev/null
+        exit 1
+    fi
+
+    echo "$proxy_port"
 }
 
 show_status() {
@@ -207,17 +272,24 @@ launch_claude() {
 
     resolve_backend
 
+    echo "  Starting model proxy for $BACKEND..."
+    local proxy_port
+    proxy_port=$(start_proxy)
+
     echo "  Launching Claude Code via $BACKEND..."
-    echo "  Endpoint: $RESOLVED_URL"
+    echo "  Proxy on :$proxy_port -> $RESOLVED_URL"
     echo "  Model: $RESOLVED_OPUS (main) + $RESOLVED_HAIKU (subagents)"
     echo ""
 
-    export ANTHROPIC_BASE_URL="$RESOLVED_URL"
-    export ANTHROPIC_AUTH_TOKEN="$RESOLVED_KEY"
+    # Route through local proxy so the model name remap fires and Claude Code
+    # sees a Claude model (unlocking auto-mode and bypassPermissions).
+    export ANTHROPIC_BASE_URL="http://127.0.0.1:$proxy_port"
     set_model_env
-    unset ANTHROPIC_API_KEY
+    # Proxy injects auth itself; the client must not also send credentials.
+    unset ANTHROPIC_API_KEY ANTHROPIC_AUTH_TOKEN
 
-    exec claude "$@"
+    # Don't exec — we want the EXIT trap to clean up the proxy.
+    claude "$@"
 }
 
 launch_remote() {
@@ -233,27 +305,8 @@ launch_remote() {
     resolve_backend
 
     echo "  Starting model proxy for $BACKEND..."
-
-    local port_file
-    port_file=$(mktemp)
-    node "$SCRIPT_DIR/proxy/start-proxy.js" "$RESOLVED_URL" "$RESOLVED_KEY" > "$port_file" &
-    PROXY_PID=$!
-
-    local tries=0
-    while [[ ! -s "$port_file" ]] && [[ $tries -lt 30 ]]; do
-        sleep 0.2
-        tries=$((tries + 1))
-    done
-
-    if [[ ! -s "$port_file" ]]; then
-        echo "ERROR: Proxy failed to start" >&2
-        rm -f "$port_file"
-        exit 1
-    fi
-
     local proxy_port
-    proxy_port=$(head -1 "$port_file")
-    rm -f "$port_file"
+    proxy_port=$(start_proxy)
 
     echo "  Proxy on :$proxy_port -> $RESOLVED_URL"
     echo "  Launching remote control via $BACKEND..."

--- a/deepclaude.sh
+++ b/deepclaude.sh
@@ -131,6 +131,12 @@ start_proxy() {
     # Wait for a line that is a bare integer (the port emitted by start-proxy.js
     # after startModelProxy resolves). The proxy also writes a human-readable
     # "[MODEL-PROXY] Listening on ..." banner first, so we can't just read line 1.
+    #
+    # Banner-ordering invariant: start-proxy.js emits the "[MODEL-PROXY]
+    # Listening on ..." banner (from the listen callback inside startModelProxy)
+    # BEFORE its final `console.log(port)`. We match the bare-numeric line to
+    # skip the banner — do not introduce other numeric-only stdout in proxy
+    # startup or this regex will pick the wrong line.
     local proxy_port=""
     local tries=0
     while [[ -z "$proxy_port" ]] && [[ $tries -lt 30 ]]; do

--- a/deepclaude.sh
+++ b/deepclaude.sh
@@ -60,24 +60,24 @@ resolve_backend() {
             key="${DEEPSEEK_API_KEY:-}"
             [[ -z "$key" ]] && { echo "ERROR: DEEPSEEK_API_KEY not set" >&2; exit 1; }
             url="$DEEPSEEK_URL"
-            opus="deepseek-v4-pro"; sonnet="deepseek-v4-pro"
+            opus="deepseek-v4-pro"; sonnet="deepseek-v4-flash"
             haiku="deepseek-v4-flash"; subagent="deepseek-v4-flash"
             ;;
         or|openrouter)
             key="${OPENROUTER_API_KEY:-}"
             [[ -z "$key" ]] && { echo "ERROR: OPENROUTER_API_KEY not set" >&2; exit 1; }
             url="$OPENROUTER_URL"
-            opus="deepseek/deepseek-v4-pro"; sonnet="deepseek/deepseek-v4-pro"
-            haiku="deepseek/deepseek-v4-pro"; subagent="deepseek/deepseek-v4-pro"
+            opus="deepseek/deepseek-v4-pro"; sonnet="deepseek/deepseek-v4-flash"
+            haiku="deepseek/deepseek-v4-flash"; subagent="deepseek/deepseek-v4-flash"
             ;;
         fw|fireworks)
             key="${FIREWORKS_API_KEY:-}"
             [[ -z "$key" ]] && { echo "ERROR: FIREWORKS_API_KEY not set" >&2; exit 1; }
             url="$FIREWORKS_URL"
             opus="accounts/fireworks/models/deepseek-v4-pro"
-            sonnet="accounts/fireworks/models/deepseek-v4-pro"
-            haiku="accounts/fireworks/models/deepseek-v4-pro"
-            subagent="accounts/fireworks/models/deepseek-v4-pro"
+            sonnet="accounts/fireworks/models/deepseek-v4-flash"
+            haiku="accounts/fireworks/models/deepseek-v4-flash"
+            subagent="accounts/fireworks/models/deepseek-v4-flash"
             ;;
         anthropic) ;;
         *) echo "ERROR: Unknown backend '$BACKEND'. Use: ds, or, fw, anthropic" >&2; exit 1 ;;

--- a/proxy/model-proxy.js
+++ b/proxy/model-proxy.js
@@ -331,7 +331,10 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
                             console.log(`[MODEL-PROXY] #${reqId} model remap: ${parsed.model} → ${mapped}`);
                             parsed.model = mapped;
                             body = Buffer.from(JSON.stringify(parsed));
-                        } else {
+                        } else if (typeof parsed.model === 'string' && parsed.model.startsWith('claude-')) {
+                            // Only warn for canonical claude-* names — those are the
+                            // ones that need a remap entry. Backend-native names
+                            // (e.g. deepseek-v4-pro) are deliberate in non-auto mode.
                             console.warn(`[MODEL-PROXY] #${reqId} WARN: no remap for "${parsed.model}" in mode "${state.mode}" — forwarding as-is`);
                         }
                     } catch { /* not JSON or parse error, pass through */ }

--- a/proxy/model-proxy.js
+++ b/proxy/model-proxy.js
@@ -22,6 +22,13 @@ const MODEL_REMAP = {
         'claude-sonnet-4-5-20250929': 'deepseek/deepseek-v4-flash',
         'claude-haiku-4-5-20251001':  'deepseek/deepseek-v4-flash',
     },
+    fireworks: {
+        'claude-opus-4-6':    'accounts/fireworks/models/deepseek-v4-pro',
+        'claude-opus-4-7':    'accounts/fireworks/models/deepseek-v4-pro',
+        'claude-sonnet-4-6':  'accounts/fireworks/models/deepseek-v4-flash',
+        'claude-sonnet-4-5-20250929': 'accounts/fireworks/models/deepseek-v4-flash',
+        'claude-haiku-4-5-20251001':  'accounts/fireworks/models/deepseek-v4-flash',
+    },
 };
 
 const PRICING_PER_M = {

--- a/proxy/model-proxy.js
+++ b/proxy/model-proxy.js
@@ -331,6 +331,8 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
                             console.log(`[MODEL-PROXY] #${reqId} model remap: ${parsed.model} → ${mapped}`);
                             parsed.model = mapped;
                             body = Buffer.from(JSON.stringify(parsed));
+                        } else {
+                            console.warn(`[MODEL-PROXY] #${reqId} WARN: no remap for "${parsed.model}" in mode "${state.mode}" — forwarding as-is`);
                         }
                     } catch { /* not JSON or parse error, pass through */ }
                 }

--- a/proxy/start-proxy.js
+++ b/proxy/start-proxy.js
@@ -7,9 +7,10 @@ const BACKEND_DEFS = {
     fireworks: { url: 'https://api.fireworks.ai/inference/v1', keyEnv: 'FIREWORKS_API_KEY' },
 };
 
-// Legacy mode: start-proxy.js <targetUrl> <apiKey> (used by deepclaude.sh/ps1)
+// Legacy mode: start-proxy.js <targetUrl> <apiKey> [defaultMode] (used by deepclaude.sh/ps1)
 const targetUrl = process.argv[2] || process.env.CHEAPCLAUDE_TARGET_URL;
 const apiKey = process.argv[3] || process.env.CHEAPCLAUDE_API_KEY;
+const legacyDefaultMode = process.argv[4] || process.env.CHEAPCLAUDE_DEFAULT_MODE;
 
 if (targetUrl && apiKey) {
     // Legacy single-backend mode
@@ -24,7 +25,7 @@ if (targetUrl && apiKey) {
         targetUrl,
         apiKey,
         backends: hasBackends ? backends : undefined,
-        defaultMode: hasBackends ? undefined : undefined,
+        defaultMode: legacyDefaultMode || undefined,
     });
     console.log(port);
 } else {


### PR DESCRIPTION
Claude Code disables `auto` and `bypassPermissions` modes when ANTHROPIC_DEFAULT_*_MODEL is not a `claude-*` value. Today deepclaude exports the resolved backend model names (e.g. `deepseek-v4-pro`) directly, which trips that gate — `Shift+Tab` reports "auto mode isn't available for this model".

This PR adds a `--auto` opt-in that swaps the env vars to canonical `claude-*` names so the gate unlocks. Default behavior is unchanged: backend-native names in env vars and TUI, no auto/bypassPermissions. The bulk of the diff is proxy hardening that's needed regardless of which mode you launch in.

## Behavior

**`deepclaude` (default, no `--auto`):**
- Proxy starts; request flows claude → proxy → deepseek (or or/fw).
- Env vars set to backend names (`deepseek-v4-pro`, `deepseek-v4-flash`, etc.).
- TUI shows the real backend model.
- Shift+Tab cannot reach auto / bypassPermissions.
- Launch banner prints:
  ```
  Auto mode: OFF (running deepseek; TUI will show 'deepseek-v4-pro')
  Tip: pass --auto to enable auto mode — TUI will show 'claude-opus-4-7' instead
  ```

**`deepclaude --auto`:**
- Same proxy path; env vars switched to canonical `claude-opus-4-7` / `claude-sonnet-4-6` / `claude-haiku-4-5-20251001`.
- Proxy `MODEL_REMAP` translates them back to backend names on the wire (`#N model remap: claude-opus-4-7 → deepseek-v4-pro` in `$PROXY_LOG`).
- TUI shows `claude-opus-4-7` (it lies — actual routing is still the configured backend).
- Shift+Tab cycles default → auto → plan → bypassPermissions.

**Caveat (auto mode only):** Claude Code's in-session UI (status bar, `/model`) shows the canonical `claude-*` name rather than the backend model — the trade-off for unlocking auto-mode. The launch banner still prints the resolved backend name, and the proxy logs every remap, so the actual routing is verifiable from outside the TUI.

## What's in the diff

**Behavior gate:**
- New `--auto` flag (default off). `set_model_env` branches on it: auto = canonical `claude-*` names, default = `$RESOLVED_OPUS` / `$RESOLVED_SONNET` / `$RESOLVED_HAIKU` / `$RESOLVED_SUBAGENT`.
- New `print_auto_mode_tip` helper called by both `launch_claude` and `launch_remote` so the trade-off is visible at launch in either mode.
- `--help` documents `--auto`.

**Proxy / launch hardening (active in both modes):**
- Route the default `launch_claude` path through the local proxy (mirrors what `launch_remote` already did), so requests go through the same code path regardless of mode.
- `start-proxy.js` legacy mode accepts an optional 3rd-positional `defaultMode`, so `state.mode` resolves to `deepseek` / `openrouter` / `fireworks` (not `_single` or `anthropic`) and `MODEL_REMAP[state.mode]` actually fires. This also fixes a latent bug in `launch_remote`, which previously left the proxy in `'anthropic'` mode and forwarded requests to `api.anthropic.com` regardless of the configured backend.
- Add Fireworks entry to `MODEL_REMAP` to match deepseek/openrouter.
- Extract a shared `start_proxy` helper used by both `launch_claude` and `launch_remote`. Symlink-resolve `SCRIPT_DIR` so deepclaude works when installed via a `/usr/local/bin/deepclaude` symlink.
- Call `start_proxy` directly (not via `$()`) so the `PROXY_PID` it sets actually reaches the parent shell — the `EXIT` trap was previously a silent no-op, leaving the node proxy orphaned on exit. `start_proxy` now sets `PROXY_PID`, `PROXY_PORT`, and `PROXY_LOG` as script globals.
- Align `RESOLVED_HAIKU` / `RESOLVED_SONNET` / `RESOLVED_SUBAGENT` with what `MODEL_REMAP` actually produces, so the launch banner matches the wire instead of advertising the pro model for slots the proxy routes to flash.
- Use a per-instance `$PROXY_LOG` path (`/tmp/deepclaude-proxy.$$.log`) so concurrent invocations don't truncate each other's logs. The resolved path is printed at launch.
- On a non-zero, non-signal `claude` exit, dump the tail of `$PROXY_LOG` to stderr so upstream proxy errors and remap warnings surface immediately. Clean exits and Ctrl+C stay silent.
- Warn in the proxy when a request arrives with a `claude-*` model name not in `MODEL_REMAP[state.mode]` — catches drift between the canonical-name list in `deepclaude.sh` and the remap table the next time Anthropic ships a model bump. Backend-native names (default-mode wire format) are passed silently.
- Document the start-proxy banner-ordering invariant that `grep -E '^[0-9]+$'` depends on, plus a sync-required note above `set_model_env`.

## Notes for reviewers
- This overlaps with draft PR #9 on the proxy-routing piece. PR #9 fixes cost-tracking but does not switch model env vars to canonical `claude-*` names, so PR #9 alone does not unlock auto mode.
- This branch deliberately does NOT alter the existing thinking-strip policy from 70518b6. A separate experiment branch tests scoping that strip down for DeepSeek; results will inform a follow-up.
- Manual verification: confirmed Shift+Tab cycles modes locally with backend `ds` under `--auto`, and that default mode shows backend names in the TUI with the expected tip in the launch banner. Static review only for `or` and `fw` paths — keys not present in test environment.
