### PR TITLE
feat: --auto flag to unlock auto/bypassPermissions modes

### DIFF
--- a/deepclaude.sh
+++ b/deepclaude.sh
@@ -25,6 +25,7 @@ BACKEND="${CHEAPCLAUDE_DEFAULT_BACKEND:-ds}"
 ACTION="launch"
 SWITCH_BACKEND=""
 PROXY_PID=""
+AUTO_MODE=0
 
 # --- Parse args ---
 while [[ $# -gt 0 ]]; do
@@ -32,6 +33,7 @@ while [[ $# -gt 0 ]]; do
         --backend|-b) BACKEND="$2"; shift 2 ;;
         --switch|-s)  ACTION="switch"; SWITCH_BACKEND="$2"; shift 2 ;;
         --remote|-r)  ACTION="remote"; shift ;;
+        --auto)       AUTO_MODE=1; shift ;;
         --status)     ACTION="status"; shift ;;
         --cost)       ACTION="cost"; shift ;;
         --benchmark)  ACTION="benchmark"; shift ;;
@@ -88,10 +90,22 @@ resolve_backend() {
 }
 
 set_model_env() {
-    export ANTHROPIC_DEFAULT_OPUS_MODEL="$RESOLVED_OPUS"
-    export ANTHROPIC_DEFAULT_SONNET_MODEL="$RESOLVED_SONNET"
-    export ANTHROPIC_DEFAULT_HAIKU_MODEL="$RESOLVED_HAIKU"
-    export CLAUDE_CODE_SUBAGENT_MODEL="$RESOLVED_SUBAGENT"
+    if [[ "$AUTO_MODE" == "1" ]]; then
+        # Claude Code's auto / bypassPermissions modes are gated on the env
+        # var being a `claude-*` name; the proxy translates back to the
+        # backend name on the wire via MODEL_REMAP. The TUI welcome chip
+        # will display the canonical name — that's the explicit tradeoff
+        # surfaced by print_auto_mode_tip at launch.
+        export ANTHROPIC_DEFAULT_OPUS_MODEL="claude-opus-4-7"
+        export ANTHROPIC_DEFAULT_SONNET_MODEL="claude-sonnet-4-6"
+        export ANTHROPIC_DEFAULT_HAIKU_MODEL="claude-haiku-4-5-20251001"
+        export CLAUDE_CODE_SUBAGENT_MODEL="claude-haiku-4-5-20251001"
+    else
+        export ANTHROPIC_DEFAULT_OPUS_MODEL="$RESOLVED_OPUS"
+        export ANTHROPIC_DEFAULT_SONNET_MODEL="$RESOLVED_SONNET"
+        export ANTHROPIC_DEFAULT_HAIKU_MODEL="$RESOLVED_HAIKU"
+        export CLAUDE_CODE_SUBAGENT_MODEL="$RESOLVED_SUBAGENT"
+    fi
     export CLAUDE_CODE_EFFORT_LEVEL="max"
 }
 
@@ -202,6 +216,8 @@ show_help() {
     echo "Options:"
     echo "  -b, --backend <ds|or|fw|anthropic>  Backend (default: ds)"
     echo "  -r, --remote                        Remote control mode (browser URL)"
+    echo "  --auto                               Unlock auto/bypassPermissions modes"
+    echo "                                       (TUI shows claude-* names; wire still routes to backend)"
     echo "  --status                             Show keys and backends"
     echo "  --cost                               Pricing comparison"
     echo "  --benchmark                          Latency test"
@@ -259,6 +275,18 @@ run_benchmark() {
     echo ""
 }
 
+print_auto_mode_tip() {
+    if [[ "$AUTO_MODE" == "1" ]]; then
+        echo "  Auto mode: ON"
+        echo "    TUI will display 'claude-opus-4-7' (auto/bypassPermissions unlocked)."
+        echo "    Actual routing: $RESOLVED_OPUS via $RESOLVED_URL."
+        echo "    Verify with: curl -s http://127.0.0.1:\$PROXY_PORT/_proxy/cost | jq"
+    else
+        echo "  Auto mode: OFF (TUI shows '$RESOLVED_OPUS')"
+        echo "    Pass --auto to unlock auto/bypassPermissions modes — TUI will then show 'claude-opus-4-7'."
+    fi
+}
+
 launch_claude() {
     if [[ "$BACKEND" == "anthropic" ]]; then
         echo "  Launching Claude Code (normal Anthropic backend)..."
@@ -278,6 +306,7 @@ launch_claude() {
     echo "  Launching Claude Code via $BACKEND..."
     echo "  Proxy on :$PROXY_PORT -> $RESOLVED_URL"
     echo "  Model: $RESOLVED_OPUS (main) + $RESOLVED_HAIKU (subagents)"
+    print_auto_mode_tip
     echo ""
 
     export ANTHROPIC_BASE_URL="http://127.0.0.1:$PROXY_PORT"
@@ -324,6 +353,7 @@ launch_remote() {
 
     echo "  Proxy on :$proxy_port -> $RESOLVED_URL"
     echo "  Launching remote control via $BACKEND..."
+    print_auto_mode_tip
     echo ""
 
     export ANTHROPIC_BASE_URL="http://127.0.0.1:$proxy_port"

--- a/deepclaude.sh
+++ b/deepclaude.sh
@@ -4,7 +4,17 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Resolve SCRIPT_DIR through any symlink chain (e.g. /usr/local/bin/deepclaude
+# -> /path/to/repo/deepclaude.sh) so $SCRIPT_DIR/proxy/... works regardless of
+# how the script was invoked.
+_source="${BASH_SOURCE[0]}"
+while [ -L "$_source" ]; do
+    _dir="$(cd "$(dirname "$_source")" && pwd)"
+    _source="$(readlink "$_source")"
+    [[ "$_source" != /* ]] && _source="$_dir/$_source"
+done
+SCRIPT_DIR="$(cd "$(dirname "$_source")" && pwd)"
+unset _source _dir
 
 # --- Config ---
 DEEPSEEK_URL="https://api.deepseek.com/anthropic"
@@ -83,6 +93,60 @@ set_model_env() {
     export ANTHROPIC_DEFAULT_HAIKU_MODEL="$RESOLVED_HAIKU"
     export CLAUDE_CODE_SUBAGENT_MODEL="$RESOLVED_SUBAGENT"
     export CLAUDE_CODE_EFFORT_LEVEL="max"
+}
+
+backend_long_name() {
+    case "$1" in
+        ds|deepseek)   echo "deepseek" ;;
+        or|openrouter) echo "openrouter" ;;
+        fw|fireworks)  echo "fireworks" ;;
+        anthropic)     echo "anthropic" ;;
+        *) echo "ERROR: Unknown backend '$1'. Use: ds, or, fw, anthropic" >&2; return 1 ;;
+    esac
+}
+
+# Sets PROXY_PID, PROXY_PORT, PROXY_LOG as script globals so the EXIT trap
+# can clean up the node child. Must be called WITHOUT command substitution
+# — $(start_proxy) runs in a subshell and globals never reach the parent.
+# Requires: RESOLVED_URL, RESOLVED_KEY, BACKEND already set.
+start_proxy() {
+    local backend_long
+    backend_long=$(backend_long_name "$BACKEND") || exit 1
+
+    PROXY_LOG="${PROXY_LOG:-/tmp/deepclaude-proxy.$$.log}"
+    : > "$PROXY_LOG"
+    node "$SCRIPT_DIR/proxy/start-proxy.js" "$RESOLVED_URL" "$RESOLVED_KEY" "$backend_long" >> "$PROXY_LOG" 2>&1 &
+    PROXY_PID=$!
+
+    # The proxy emits a banner line, then a bare-numeric port line on a
+    # successful bind. Match the bare integer to skip the banner; do not
+    # introduce other numeric-only stdout in proxy startup.
+    local proxy_port=""
+    local tries=0
+    while [[ -z "$proxy_port" ]] && [[ $tries -lt 30 ]]; do
+        if kill -0 "$PROXY_PID" 2>/dev/null; then
+            # `|| true`: with `set -o pipefail`, grep no-match (exit 1)
+            # would otherwise exit the script; we expect zero matches on
+            # early iterations before the proxy has emitted its port.
+            proxy_port=$(grep -E '^[0-9]+$' "$PROXY_LOG" 2>/dev/null | head -1 || true)
+        else
+            echo "ERROR: Proxy process died during startup" >&2
+            echo "  Log: $PROXY_LOG" >&2
+            tail -20 "$PROXY_LOG" >&2 2>/dev/null
+            exit 1
+        fi
+        [[ -z "$proxy_port" ]] && sleep 0.2
+        tries=$((tries + 1))
+    done
+
+    if [[ -z "$proxy_port" ]]; then
+        echo "ERROR: Proxy failed to report a port within 6s" >&2
+        echo "  Log: $PROXY_LOG" >&2
+        tail -20 "$PROXY_LOG" >&2 2>/dev/null
+        exit 1
+    fi
+
+    PROXY_PORT="$proxy_port"
 }
 
 show_status() {
@@ -207,17 +271,20 @@ launch_claude() {
 
     resolve_backend
 
+    echo "  Starting model proxy for $BACKEND..."
+    start_proxy
+    echo "  Proxy log: $PROXY_LOG"
+
     echo "  Launching Claude Code via $BACKEND..."
-    echo "  Endpoint: $RESOLVED_URL"
+    echo "  Proxy on :$PROXY_PORT -> $RESOLVED_URL"
     echo "  Model: $RESOLVED_OPUS (main) + $RESOLVED_HAIKU (subagents)"
     echo ""
 
-    export ANTHROPIC_BASE_URL="$RESOLVED_URL"
-    export ANTHROPIC_AUTH_TOKEN="$RESOLVED_KEY"
+    export ANTHROPIC_BASE_URL="http://127.0.0.1:$PROXY_PORT"
     set_model_env
-    unset ANTHROPIC_API_KEY
 
-    exec claude "$@"
+    # Don't `exec` — the EXIT trap needs to fire to stop the proxy.
+    claude "$@"
 }
 
 launch_remote() {

--- a/proxy/model-proxy.js
+++ b/proxy/model-proxy.js
@@ -22,6 +22,13 @@ const MODEL_REMAP = {
         'claude-sonnet-4-5-20250929': 'deepseek/deepseek-v4-flash',
         'claude-haiku-4-5-20251001':  'deepseek/deepseek-v4-flash',
     },
+    fireworks: {
+        'claude-opus-4-6':    'accounts/fireworks/models/deepseek-v4-pro',
+        'claude-opus-4-7':    'accounts/fireworks/models/deepseek-v4-pro',
+        'claude-sonnet-4-6':  'accounts/fireworks/models/deepseek-v4-flash',
+        'claude-sonnet-4-5-20250929': 'accounts/fireworks/models/deepseek-v4-flash',
+        'claude-haiku-4-5-20251001':  'accounts/fireworks/models/deepseek-v4-flash',
+    },
 };
 
 const PRICING_PER_M = {
@@ -324,6 +331,11 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
                             console.log(`[MODEL-PROXY] #${reqId} model remap: ${parsed.model} → ${mapped}`);
                             parsed.model = mapped;
                             body = Buffer.from(JSON.stringify(parsed));
+                        } else if (parsed.model?.startsWith('claude-')) {
+                            // Caught a claude-* name with no entry — usually
+                            // means MODEL_REMAP fell behind an Anthropic model
+                            // bump. Log so the gap is visible.
+                            console.warn(`[MODEL-PROXY] #${reqId} WARN: no MODEL_REMAP[${state.mode}] entry for ${parsed.model}; forwarding as-is`);
                         }
                     } catch { /* not JSON or parse error, pass through */ }
                 }

--- a/proxy/start-proxy.js
+++ b/proxy/start-proxy.js
@@ -7,9 +7,10 @@ const BACKEND_DEFS = {
     fireworks: { url: 'https://api.fireworks.ai/inference/v1', keyEnv: 'FIREWORKS_API_KEY' },
 };
 
-// Legacy mode: start-proxy.js <targetUrl> <apiKey> (used by deepclaude.sh/ps1)
+// Legacy mode: start-proxy.js <targetUrl> <apiKey> [defaultMode] (used by deepclaude.sh/ps1)
 const targetUrl = process.argv[2] || process.env.CHEAPCLAUDE_TARGET_URL;
 const apiKey = process.argv[3] || process.env.CHEAPCLAUDE_API_KEY;
+const legacyDefaultMode = process.argv[4] || process.env.CHEAPCLAUDE_DEFAULT_MODE;
 
 if (targetUrl && apiKey) {
     // Legacy single-backend mode
@@ -24,7 +25,7 @@ if (targetUrl && apiKey) {
         targetUrl,
         apiKey,
         backends: hasBackends ? backends : undefined,
-        defaultMode: hasBackends ? undefined : undefined,
+        defaultMode: legacyDefaultMode || undefined,
     });
     console.log(port);
 } else {


### PR DESCRIPTION
Claude Code disables `auto` and `bypassPermissions` permission modes when `ANTHROPIC_DEFAULT_*_MODEL` is not a `claude-*` value. Default deepclaude exports the resolved backend name (`deepseek-v4-pro` etc.) so the gate stays locked and `Shift+Tab` reports "auto mode isn't available for this model".

This PR adds an opt-in `--auto` flag. When passed, `set_model_env` exports canonical `claude-opus-4-7` / `claude-sonnet-4-6` / `claude-haiku-4-5-20251001` in place of the backend names. The proxy translates them back to the configured backend on the wire via `MODEL_REMAP`. The TUI's welcome chip will display the canonical name — that's the explicit, opt-in tradeoff for unlocking the gate.

Default behaviour is unchanged: backend names in env vars and TUI, no auto/bypassPermissions, no model remap fires.

## Why opt-in

Surfacing the right tradeoff at launch matters because deepclaude's premise is cost savings — silently lying about the model in the TUI would mislead users about where their tokens are landing. With `--auto`, the user is asking for the gate to be unlocked; they accept the TUI showing a Claude name in exchange. With `--auto` off, everything stays honest by default.

The launch banner makes the tradeoff explicit either way:

```
# deepclaude
Auto mode: OFF (TUI shows 'deepseek-v4-pro')
  Pass --auto to unlock auto/bypassPermissions modes — TUI will then show 'claude-opus-4-7'.

# deepclaude --auto
Auto mode: ON
  TUI will display 'claude-opus-4-7' (auto/bypassPermissions unlocked).
  Actual routing: deepseek-v4-pro via https://api.deepseek.com/anthropic.
  Verify with: curl -s http://127.0.0.1:$PROXY_PORT/_proxy/cost | jq
```

A future PR will add a Claude Code statusLine integration so the actual backend (and live cost) is also visible at the bottom of the terminal — the natural counterpart to a TUI chip that lies under `--auto`.

## What's in the diff

**`--auto` core:**
- `AUTO_MODE` global + `--auto)` arg parsing.
- `set_model_env` branched on `$AUTO_MODE`: canonical `claude-*` names under `--auto`, `$RESOLVED_*` otherwise.
- `print_auto_mode_tip` helper surfacing the tradeoff and the actual routing destination at launch (called from both `launch_claude` and `launch_remote`).
- `--auto` documented in `show_help`.

**Proxy / launch foundation (active in both modes — not auto-mode-specific, but required for `--auto` to function):**
- `launch_claude` now starts the local proxy and points `ANTHROPIC_BASE_URL` at it. Previously only `--remote` did this.
- `start_proxy` shared helper sets `PROXY_PID`/`PROXY_PORT`/`PROXY_LOG` as script globals; must be called without `$()` or the EXIT trap leaks the node child.
- `SCRIPT_DIR` is symlink-resolved so deepclaude works when installed via a `~/.local/bin` symlink.
- `start-proxy.js` legacy mode accepts an optional `[defaultMode]` third argv so `state.mode` resolves to e.g. `deepseek` rather than `_single` and `MODEL_REMAP[state.mode]` actually fires.
- `launch_claude` deliberately does not touch `ANTHROPIC_AUTH_TOKEN` — whatever Claude Code is already carrying flows through; the proxy injects backend auth itself for non-image, non-Anthropic calls.

**Adjacent proxy additions:**
- `MODEL_REMAP['fireworks']` block, mirroring the deepseek/openrouter entries, so `--auto` works on the fireworks backend.
- `console.warn` line in the existing remap branch when an inbound `claude-*` name has no `MODEL_REMAP` entry — drift detector for when Anthropic ships a new model and the table falls behind.

## Test plan

- [x] `deepclaude` (no `--auto`): TUI shows `deepseek-v4-pro`, `Shift+Tab` doesn't include auto/bypassPermissions, requests route through the proxy to DeepSeek.
- [x] `deepclaude --auto`: TUI shows `claude-opus-4-7`, `Shift+Tab` cycles default → auto → plan → bypassPermissions, requests still route to DeepSeek (proxy log: `model remap: claude-opus-4-7 → deepseek-v4-pro`).
- [x] Launch banner prints the appropriate auto-mode tip on both paths.
- [x] `curl http://127.0.0.1:$PROXY_PORT/_proxy/status` reports `"mode": "deepseek"` (i.e. the `defaultMode` argv plumbing works); `/_proxy/cost` accumulates a `deepseek` bucket on each turn.

## Notes

This PR overlaps with #21 on the proxy-in-path foundation (`start_proxy`, symlink-resolved `SCRIPT_DIR`, `launch_claude` routing through proxy, `start-proxy.js` `[defaultMode]` argv). When either PR merges first, the other can rebase onto main; git will recognise the duplicate patches and drop them. The auto-mode-only delta (~50 lines across `deepclaude.sh` and `proxy/model-proxy.js`) is what survives in this PR after such a rebase.