### PR TITLE
fix: thinking-block continuity on non-Anthropic backends

### DIFF
--- a/proxy/model-proxy.js
+++ b/proxy/model-proxy.js
@@ -349,6 +349,13 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
                     try {
                         const parsed = JSON.parse(body);
                         stripAllThinkingBlocks(parsed);
+                        // Top-level thinking/context_management have to go too.
+                        // DeepSeek 400s with "content[].thinking in the thinking
+                        // mode must be passed back" when the body advertises
+                        // thinking but messages don't carry the blocks (which
+                        // we just stripped, since foreign blocks are invalid).
+                        delete parsed.thinking;
+                        delete parsed.context_management;
                         body = Buffer.from(JSON.stringify(parsed));
                     } catch { /* pass through */ }
                 }

--- a/proxy/model-proxy.js
+++ b/proxy/model-proxy.js
@@ -348,12 +348,14 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
                 if (isModelCall) {
                     try {
                         const parsed = JSON.parse(body);
-                        stripAllThinkingBlocks(parsed);
-                        // Top-level thinking/context_management have to go too.
-                        // DeepSeek 400s with "content[].thinking in the thinking
-                        // mode must be passed back" when the body advertises
-                        // thinking but messages don't carry the blocks (which
-                        // we just stripped, since foreign blocks are invalid).
+                        // DeepSeek's anthropic-compat endpoint expects its own
+                        // thinking blocks passed back verbatim for continuity
+                        // ("content[].thinking ... must be passed back"), so
+                        // we don't strip thinking blocks here. Top-level
+                        // thinking/context_management still go — non-Anthropic
+                        // backends don't honor Anthropic's extended-thinking
+                        // spec consistently, and a stale config field is a
+                        // noisier error than no config at all.
                         delete parsed.thinking;
                         delete parsed.context_management;
                         body = Buffer.from(JSON.stringify(parsed));


### PR DESCRIPTION
DeepSeek's anthropic-compat endpoint returns 400 mid-conversation:

```
API Error: 400 The `content[].thinking` in the thinking mode must be passed back to the API.
```

…once Claude Code emits a thinking block in any assistant turn. The proxy was both stripping all thinking blocks from messages AND leaving the top-level `thinking: { type: "enabled", ... }` field in the request body, creating a contradictory state DeepSeek rejects.

Two fixes in this PR:

**1. Drop top-level `thinking` and `context_management` on non-Anthropic routes.** Backends like DeepSeek don't honor Anthropic's extended-thinking spec consistently, and a stale config field is a noisier error than no config at all.

**2. Stop stripping thinking blocks on `isModelCall`.** The original strip from commit 70518b6 was added to clean up foreign-backend blocks on backend switches — but it's too broad for pure-DeepSeek sessions, where DeepSeek's own prior thinking blocks are valid and required for continuity. Removing the strip unblocks the conversation.

Backend-switch case (e.g. DeepSeek session → Anthropic) is still handled by the **Anthropic-side** strip (`hadNonAnthropicSession ? stripAllThinkingBlocks : stripUnsignedThinkingBlocks`), which doesn't change in this PR.

## Test plan

- [x] Plain conversation with `deepclaude` (default mode, DeepSeek): multiple turns including tool use, no 400s.
- [x] Same conversation that previously hit the 400 reliably (after Claude Code emitted a thinking block) now goes through.
- [x] Proxy log shows status 200 across the board.

## Notes

This bug also affects `feat/cost-statusline` (#23) and any branch that descends from main while keeping the original strip. Both fixes are also present on #23 by virtue of being committed there first; when one PR merges, the other's rebase will recognise the duplicate patches and drop them.