### PR TITLE
Mid-session backend switching: stateless redesign + subscription-friendly wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,17 @@ Claude Code reads these environment variables to determine where to send API cal
 
 | Variable | What it does |
 |---|---|
-| `ANTHROPIC_BASE_URL` | API endpoint (default: api.anthropic.com) |
-| `ANTHROPIC_AUTH_TOKEN` | API key for the backend |
-| `ANTHROPIC_DEFAULT_OPUS_MODEL` | Model name for Opus-tier tasks |
-| `ANTHROPIC_DEFAULT_SONNET_MODEL` | Model name for Sonnet-tier tasks |
-| `ANTHROPIC_DEFAULT_HAIKU_MODEL` | Model name for Haiku-tier (subagents) |
+| `ANTHROPIC_BASE_URL` | API endpoint — deepclaude points this at the local proxy (`http://127.0.0.1:3200`) |
+| `ANTHROPIC_DEFAULT_OPUS_MODEL` | Canonical Claude model name (e.g. `claude-opus-4-7`) — proxy remaps per backend |
+| `ANTHROPIC_DEFAULT_SONNET_MODEL` | Same — proxy translates to `deepseek-v4-pro` etc. |
+| `ANTHROPIC_DEFAULT_HAIKU_MODEL` | Same — used for subagents |
 | `CLAUDE_CODE_SUBAGENT_MODEL` | Model for spawned subagents |
+| `DEEPSEEK_API_KEY` / `OPENROUTER_API_KEY` / `FIREWORKS_API_KEY` | Per-backend keys — proxy substitutes the right one per request |
+| `ANTHROPIC_API_KEY` | (Optional) Required only for mid-session `/anthropic` switching. Without it the proxy refuses anthropic mode and tells you to relaunch in `-b anthropic`. |
 
-**deepclaude** sets these per-session (not permanently), launches Claude Code, then restores your original settings on exit.
+**deepclaude** points Claude Code at the local proxy on `127.0.0.1:3200`. Your client auth (subscription OAuth or `ANTHROPIC_API_KEY`) flows through unchanged — the proxy strips it and substitutes the correct backend key per request, so you never have to set per-backend tokens for Claude Code itself.
+
+The proxy is launched per-session and shut down on exit. Logs go to `/tmp/proxy.log` (or `%TEMP%\deepclaude-proxy.log` on Windows) for diagnostics.
 
 ## Supported backends
 
@@ -110,6 +113,13 @@ export OPENROUTER_API_KEY="sk-or-..."    # macOS/Linux
 setx FIREWORKS_API_KEY "fw_..."          # Windows
 export FIREWORKS_API_KEY="fw_..."        # macOS/Linux
 ```
+
+**Anthropic** (optional, for mid-session `/anthropic` switching):
+```bash
+setx ANTHROPIC_API_KEY "sk-ant-api03-..."     # Windows
+export ANTHROPIC_API_KEY="sk-ant-api03-..."   # macOS/Linux
+```
+Required only if you want to flip into Anthropic mode mid-session via `/anthropic`. Without it, mid-session anthropic is unavailable but you can still run `deepclaude -b anthropic` for a pure-anthropic launch (uses your subscription).
 
 ## Cost comparison
 
@@ -147,7 +157,19 @@ DeepSeek's automatic context caching makes agent loops extremely cheap - after t
 
 ## Live switching (no restart)
 
-Switch between Anthropic and DeepSeek **mid-session** - from inside Claude Code itself. No restart, no terminal commands. Just type a slash command.
+Switch between Anthropic, DeepSeek, OpenRouter, and Fireworks **mid-session** — from inside Claude Code itself. No restart, no terminal commands. Just type a slash command.
+
+**Prerequisite for `/anthropic` mid-session switch:** set `ANTHROPIC_API_KEY` in your env BEFORE launching the wrapper. The proxy reads it at startup and substitutes it for `/anthropic` requests. Without it, the proxy refuses the switch with a clear error directing you to relaunch with `deepclaude -b anthropic`.
+
+```bash
+# enable full mid-session switching
+export ANTHROPIC_API_KEY=sk-ant-api03-...   # macOS/Linux
+$env:ANTHROPIC_API_KEY = "sk-ant-api03-..."  # Windows PowerShell
+
+deepclaude   # then /deepseek, /anthropic, /openrouter inside the TUI all work
+```
+
+**The hard architectural rule (finalized in this release):** every cross-mode switch is *path-isolated* — the proxy classifies thinking blocks by signature shape, strips foreign-signed blocks, and disables thinking-mode + clears `output_config` whenever any assistant turn in conversation history lacks a thinking block (DeepSeek's per-turn continuity rule). This eliminates the `content[].thinking ... must be passed back` 400-error class that previously fired on any `anthropic → deepseek` round-trip.
 
 **In Claude Code terminal:**
 

--- a/deepclaude.ps1
+++ b/deepclaude.ps1
@@ -3,15 +3,20 @@
     deepclaude — Use Claude Code with DeepSeek V4 Pro or other cheap backends.
 
 .USAGE
-    deepclaude                      # DeepSeek V4 Pro (default)
-    deepclaude --backend or         # OpenRouter (cheapest)
-    deepclaude --backend fw         # Fireworks AI (fastest)
-    deepclaude --backend anthropic  # Normal Claude Code
+    deepclaude                      # DeepSeek via proxy (default; subscription-friendly)
+    deepclaude --backend or         # OpenRouter via proxy
+    deepclaude --backend fw         # Fireworks via proxy
+    deepclaude --backend anthropic  # Direct Claude Code (no proxy)
     deepclaude --remote             # Remote control + DeepSeek (browser URL)
     deepclaude --remote -b or       # Remote control + OpenRouter
     deepclaude --status             # Show keys and backends
     deepclaude --cost               # Pricing comparison
     deepclaude --benchmark          # Latency test
+
+.NOTES
+    For mid-session /anthropic switching, set ANTHROPIC_API_KEY in env BEFORE launching.
+    The proxy reads it at startup and substitutes per-mode. Without it, /anthropic
+    is refused with a clear error directing you to relaunch in -b anthropic.
 #>
 
 param(
@@ -31,7 +36,7 @@ if (-not $Backend -and -not $Status -and -not $Cost -and -not $Benchmark -and -n
     $Backend = if ($env:CHEAPCLAUDE_DEFAULT_BACKEND) { $env:CHEAPCLAUDE_DEFAULT_BACKEND } else { "ds" }
 }
 
-# --- Config ---
+# --- Config: resolve all keys from process env or User scope ---
 $DeepSeekKey = if ($env:DEEPSEEK_API_KEY) { $env:DEEPSEEK_API_KEY } else {
     [Environment]::GetEnvironmentVariable("DEEPSEEK_API_KEY", "User")
 }
@@ -41,36 +46,101 @@ $OpenRouterKey = if ($env:OPENROUTER_API_KEY) { $env:OPENROUTER_API_KEY } else {
 $FireworksKey = if ($env:FIREWORKS_API_KEY) { $env:FIREWORKS_API_KEY } else {
     [Environment]::GetEnvironmentVariable("FIREWORKS_API_KEY", "User")
 }
+$AnthropicApiKey = if ($env:ANTHROPIC_API_KEY) { $env:ANTHROPIC_API_KEY } else {
+    [Environment]::GetEnvironmentVariable("ANTHROPIC_API_KEY", "User")
+}
 
 $Providers = @{
     ds = @{
-        name = "DeepSeek (direct)"
+        name = "DeepSeek (via proxy)"
         url = "https://api.deepseek.com/anthropic"
         key = $DeepSeekKey; keyName = "DEEPSEEK_API_KEY"
-        opus = "deepseek-v4-pro"; sonnet = "deepseek-v4-pro"
-        haiku = "deepseek-v4-flash"; subagent = "deepseek-v4-flash"
+        backendId = "deepseek"
+        opus = "deepseek-v4-pro"; haiku = "deepseek-v4-flash"
     }
     or = @{
-        name = "OpenRouter"
+        name = "OpenRouter (via proxy)"
         url = "https://openrouter.ai/api"
         key = $OpenRouterKey; keyName = "OPENROUTER_API_KEY"
-        opus = "deepseek/deepseek-v4-pro"; sonnet = "deepseek/deepseek-v4-pro"
-        haiku = "deepseek/deepseek-v4-pro"; subagent = "deepseek/deepseek-v4-pro"
+        backendId = "openrouter"
+        opus = "deepseek/deepseek-v4-pro"; haiku = "deepseek/deepseek-v4-pro"
     }
     fw = @{
-        name = "Fireworks AI"
+        name = "Fireworks AI (via proxy)"
         url = "https://api.fireworks.ai/inference"
         key = $FireworksKey; keyName = "FIREWORKS_API_KEY"
-        opus = "accounts/fireworks/models/deepseek-v4-pro"
-        sonnet = "accounts/fireworks/models/deepseek-v4-pro"
-        haiku = "accounts/fireworks/models/deepseek-v4-pro"
-        subagent = "accounts/fireworks/models/deepseek-v4-pro"
+        backendId = "fireworks"
+        opus = "accounts/fireworks/models/deepseek-v4-pro"; haiku = "accounts/fireworks/models/deepseek-v4-pro"
     }
 }
 
 function Get-KeyDisplay($k) {
     if (-not $k) { return "MISSING" }
     return "set (****" + $k.Substring($k.Length - [Math]::Min(4, $k.Length)) + ")"
+}
+
+# Set canonical Claude model names so the proxy's MODEL_REMAP can forward-map
+# per backend mode. Anthropic mode passes through unchanged. This makes
+# mid-session /anthropic /deepseek /openrouter /fireworks switches all work.
+function Set-ClaudeModelEnv {
+    $env:ANTHROPIC_DEFAULT_OPUS_MODEL = "claude-opus-4-7"
+    $env:ANTHROPIC_DEFAULT_SONNET_MODEL = "claude-sonnet-4-6"
+    $env:ANTHROPIC_DEFAULT_HAIKU_MODEL = "claude-haiku-4-5"
+    $env:CLAUDE_CODE_SUBAGENT_MODEL = "claude-opus-4-7"
+    $env:CLAUDE_CODE_EFFORT_LEVEL = "max"
+}
+
+# Spawn proxy, detect port robustly (numeric-only line — proxy banner prints
+# first, the port number after; old code's Select-Object -First 1 grabbed
+# the banner). Auto-switch to chosen backend mode after spawn.
+function Start-ProxyAndDetectPort {
+    param([string]$Url, [string]$Key, [string]$BackendId, [string]$ScriptDir)
+
+    $proxyScript = Join-Path $ScriptDir "proxy\start-proxy.js"
+    $portFile = Join-Path $env:TEMP "deepclaude-proxy-port.txt"
+    $logFile = Join-Path $env:TEMP "deepclaude-proxy.log"
+
+    if (Test-Path $portFile) { Remove-Item $portFile -ErrorAction SilentlyContinue }
+
+    # ANTHROPIC_API_KEY in env is inherited by the child node process. Proxy
+    # reads it at startup for /anthropic mode-substitution.
+    $proxyProc = Start-Process -FilePath "node" `
+        -ArgumentList $proxyScript,$Url,$Key `
+        -PassThru -WindowStyle Hidden `
+        -RedirectStandardOutput $portFile `
+        -RedirectStandardError $logFile
+
+    $proxyPort = $null
+    for ($i = 0; $i -lt 30; $i++) {
+        Start-Sleep -Milliseconds 200
+        if (Test-Path $portFile) {
+            $content = Get-Content $portFile -ErrorAction SilentlyContinue
+            $proxyPort = $content | Where-Object { $_ -match '^\d+$' } | Select-Object -First 1
+            if ($proxyPort) { break }
+        }
+    }
+    Remove-Item $portFile -ErrorAction SilentlyContinue
+
+    if (-not $proxyPort) {
+        Write-Host "ERROR: Proxy failed to start (port not detected)" -ForegroundColor Red
+        if ($proxyProc -and -not $proxyProc.HasExited) {
+            Stop-Process -Id $proxyProc.Id -Force -ErrorAction SilentlyContinue
+        }
+        return $null
+    }
+
+    # Switch proxy to chosen backend (legacy startup defaults to anthropic).
+    if ($BackendId -and $BackendId -ne "anthropic") {
+        try {
+            Invoke-WebRequest -Uri "http://127.0.0.1:$proxyPort/_proxy/mode" `
+                -Method POST -Body "backend=$BackendId" `
+                -UseBasicParsing -TimeoutSec 5 | Out-Null
+        } catch {
+            Write-Host "  WARN: failed to set initial proxy mode to $BackendId" -ForegroundColor Yellow
+        }
+    }
+
+    return @{ Port = $proxyPort; Process = $proxyProc; LogFile = $logFile }
 }
 
 # --- Status ---
@@ -81,11 +151,12 @@ if ($Status) {
     Write-Host "    DEEPSEEK_API_KEY:    $(Get-KeyDisplay $DeepSeekKey)"
     Write-Host "    OPENROUTER_API_KEY:  $(Get-KeyDisplay $OpenRouterKey)"
     Write-Host "    FIREWORKS_API_KEY:   $(Get-KeyDisplay $FireworksKey)"
+    Write-Host "    ANTHROPIC_API_KEY:   $(Get-KeyDisplay $AnthropicApiKey)  (for /anthropic mid-session)"
     Write-Host "`n  Backends:" -ForegroundColor Yellow
-    Write-Host "    deepclaude              # DeepSeek V4 Pro (default)"
-    Write-Host "    deepclaude -b or        # OpenRouter (cheapest)"
-    Write-Host "    deepclaude -b fw        # Fireworks AI (fastest)"
-    Write-Host "    deepclaude -b anthropic # Normal Claude Code"
+    Write-Host "    deepclaude              # DeepSeek V4 Pro via proxy (default)"
+    Write-Host "    deepclaude -b or        # OpenRouter via proxy"
+    Write-Host "    deepclaude -b fw        # Fireworks AI via proxy"
+    Write-Host "    deepclaude -b anthropic # Direct Claude (no proxy)"
     Write-Host ""
     exit 0
 }
@@ -102,28 +173,26 @@ if ($Cost) {
     Write-Host "  Fireworks       `$1.74      `$3.48      (provider)"
     Write-Host "  Anthropic       `$3.00      `$15.00     `$0.30"
     Write-Host ""
-    Write-Host "  Monthly estimate (heavy use): `$30-80 vs `$200 Anthropic" -ForegroundColor Green
-    Write-Host ""
     exit 0
 }
 
 # --- Help ---
 if ($Help) {
-    Write-Host "deepclaude - Claude Code with cheap backends"
+    Write-Host "deepclaude - Claude Code with cheap backends (subscription-friendly)"
     Write-Host ""
-    Write-Host "Usage: deepclaude [-b backend] [--status] [--cost] [--benchmark]"
+    Write-Host "Usage: deepclaude [-b backend] [--remote] [--status] [--cost] [--benchmark]"
     Write-Host ""
     Write-Host "  -b, --backend   ds (default), or, fw, anthropic"
-    Write-Host "  --status        Show keys and backends"
-    Write-Host "  --cost          Pricing comparison"
-    Write-Host "  --benchmark     Latency test"
+    Write-Host "  -r, --remote    Remote control mode (browser URL)"
+    Write-Host ""
+    Write-Host "Mid-session switching: set ANTHROPIC_API_KEY in env BEFORE launching"
+    Write-Host "  to enable /anthropic /deepseek /openrouter /fireworks slash commands."
     exit 0
 }
 
 # --- Benchmark ---
 if ($Benchmark) {
     Write-Host "`n  Latency Benchmark" -ForegroundColor Cyan
-    Write-Host "  ==================" -ForegroundColor DarkGray
     foreach ($id in @("ds","or","fw")) {
         $p = $Providers[$id]
         Write-Host "  $($p.name)..." -NoNewline
@@ -142,8 +211,7 @@ if ($Benchmark) {
             Write-Host " OK ($($sw.ElapsedMilliseconds)ms)" -ForegroundColor Green
         } catch {
             $sw.Stop()
-            $code = if ($_.Exception.Response) { $_.Exception.Response.StatusCode.value__ } else { "timeout" }
-            Write-Host " FAIL ($code, $($sw.ElapsedMilliseconds)ms)" -ForegroundColor Red
+            Write-Host " FAIL ($($sw.ElapsedMilliseconds)ms)" -ForegroundColor Red
         }
     }
     Write-Host ""
@@ -170,87 +238,86 @@ if ($Remote) {
     if (-not $p.key) { Write-Host "ERROR: $($p.keyName) not set" -ForegroundColor Red; exit 1 }
 
     Write-Host "`n  Starting model proxy for $($p.name)..." -ForegroundColor Cyan
-
-    $proxyScript = Join-Path $ScriptDir "proxy\start-proxy.js"
-    $proxyProc = Start-Process -FilePath "node" -ArgumentList $proxyScript,$p.url,$p.key -PassThru -WindowStyle Hidden -RedirectStandardOutput "$env:TEMP\deepclaude-proxy-port.txt"
-
-    $tries = 0
-    while ($tries -lt 30) {
-        Start-Sleep -Milliseconds 200
-        $tries++
-        if (Test-Path "$env:TEMP\deepclaude-proxy-port.txt") {
-            $content = Get-Content "$env:TEMP\deepclaude-proxy-port.txt" -ErrorAction SilentlyContinue
-            if ($content) { break }
-        }
+    if (-not $AnthropicApiKey) {
+        Write-Host "  WARN: ANTHROPIC_API_KEY not set -- /anthropic mid-session will 401." -ForegroundColor Yellow
     }
 
-    $proxyPort = (Get-Content "$env:TEMP\deepclaude-proxy-port.txt" -ErrorAction SilentlyContinue | Select-Object -First 1)
-    Remove-Item "$env:TEMP\deepclaude-proxy-port.txt" -ErrorAction SilentlyContinue
+    $proxy = Start-ProxyAndDetectPort -Url $p.url -Key $p.key -BackendId $p.backendId -ScriptDir $ScriptDir
+    if (-not $proxy) { exit 1 }
 
-    if (-not $proxyPort) {
-        Write-Host "ERROR: Proxy failed to start" -ForegroundColor Red
-        if ($proxyProc -and -not $proxyProc.HasExited) { Stop-Process -Id $proxyProc.Id -Force }
-        exit 1
-    }
+    Write-Host "  Proxy on :$($proxy.Port) -> $($p.url) ($Backend)" -ForegroundColor DarkGray
+    Write-Host "  Log: $($proxy.LogFile)" -ForegroundColor DarkGray
+    Write-Host ""
 
-    Write-Host "  Proxy on :$proxyPort -> $($p.url)" -ForegroundColor DarkGray
-    Write-Host "  Launching remote control via $($p.name)...`n" -ForegroundColor Cyan
-
-    $env:ANTHROPIC_BASE_URL = "http://127.0.0.1:$proxyPort"
-    $env:ANTHROPIC_DEFAULT_OPUS_MODEL = $p.opus
-    $env:ANTHROPIC_DEFAULT_SONNET_MODEL = $p.sonnet
-    $env:ANTHROPIC_DEFAULT_HAIKU_MODEL = $p.haiku
-    $env:CLAUDE_CODE_SUBAGENT_MODEL = $p.subagent
-    $env:CLAUDE_CODE_EFFORT_LEVEL = "max"
+    $env:ANTHROPIC_BASE_URL = "http://127.0.0.1:$($proxy.Port)"
+    Set-ClaudeModelEnv
     Remove-Item Env:ANTHROPIC_API_KEY -ErrorAction SilentlyContinue
     Remove-Item Env:ANTHROPIC_AUTH_TOKEN -ErrorAction SilentlyContinue
 
     try {
         & claude remote-control @Args
     } finally {
-        if ($proxyProc -and -not $proxyProc.HasExited) {
-            Stop-Process -Id $proxyProc.Id -Force -ErrorAction SilentlyContinue
+        if ($proxy.Process -and -not $proxy.Process.HasExited) {
+            Stop-Process -Id $proxy.Process.Id -Force -ErrorAction SilentlyContinue
             Write-Host "  Proxy stopped." -ForegroundColor DarkGray
         }
     }
     exit 0
 }
 
-# --- Launch ---
+# --- Launch (non-remote) ---
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+
+# Path 1: anthropic mode = plain claude under whatever auth is configured.
 if ($Backend -eq "anthropic") {
     foreach ($v in @("ANTHROPIC_BASE_URL","ANTHROPIC_AUTH_TOKEN","ANTHROPIC_DEFAULT_OPUS_MODEL",
         "ANTHROPIC_DEFAULT_SONNET_MODEL","ANTHROPIC_DEFAULT_HAIKU_MODEL",
         "CLAUDE_CODE_SUBAGENT_MODEL","CLAUDE_CODE_EFFORT_LEVEL")) {
         Remove-Item "Env:$v" -ErrorAction SilentlyContinue
     }
-    Write-Host "`n  Launching Claude Code (normal Anthropic)...`n" -ForegroundColor Cyan
+    Write-Host "`n  Launching Claude Code (normal Anthropic backend)...`n" -ForegroundColor Cyan
     & claude @Args
     exit 0
 }
 
+# Path 2: cheap backend via proxy (subscription-friendly).
+# CRITICAL: do NOT set ANTHROPIC_AUTH_TOKEN. Let the user's existing auth
+# (subscription OAuth or ANTHROPIC_API_KEY) flow through. The proxy
+# substitutes the backend's API key per request.
 $p = $Providers[$Backend]
 if (-not $p) { Write-Host "ERROR: Unknown backend '$Backend'. Use: ds, or, fw, anthropic" -ForegroundColor Red; exit 1 }
 if (-not $p.key) { Write-Host "ERROR: $($p.keyName) not set" -ForegroundColor Red; exit 1 }
 
-Write-Host "`n  Launching Claude Code via $($p.name)..." -ForegroundColor Cyan
-Write-Host "  Endpoint: $($p.url)" -ForegroundColor DarkGray
+Write-Host "`n  Starting model proxy for $Backend..." -ForegroundColor Cyan
+if (-not $AnthropicApiKey) {
+    Write-Host "  Note: /anthropic mid-session switch unavailable (no ANTHROPIC_API_KEY)." -ForegroundColor Yellow
+    Write-Host "        For anthropic mode, exit and run: deepclaude -b anthropic" -ForegroundColor Yellow
+}
+
+$proxy = Start-ProxyAndDetectPort -Url $p.url -Key $p.key -BackendId $p.backendId -ScriptDir $ScriptDir
+if (-not $proxy) { exit 1 }
+
+Write-Host "  Proxy on :$($proxy.Port) -> $($p.url) ($Backend)" -ForegroundColor DarkGray
 Write-Host "  Model: $($p.opus) (main) + $($p.haiku) (subagents)" -ForegroundColor DarkGray
+Write-Host "  Auth: passthrough (subscription OAuth or ANTHROPIC_API_KEY)" -ForegroundColor DarkGray
+Write-Host "  Log: $($proxy.LogFile)" -ForegroundColor DarkGray
 Write-Host ""
 
-$env:ANTHROPIC_BASE_URL = $p.url
-$env:ANTHROPIC_AUTH_TOKEN = $p.key
-$env:ANTHROPIC_MODEL = $p.opus
-$env:ANTHROPIC_DEFAULT_OPUS_MODEL = $p.opus
-$env:ANTHROPIC_DEFAULT_SONNET_MODEL = $p.sonnet
-$env:ANTHROPIC_DEFAULT_HAIKU_MODEL = $p.haiku
-$env:CLAUDE_CODE_SUBAGENT_MODEL = $p.subagent
-$env:CLAUDE_CODE_EFFORT_LEVEL = "max"
-Remove-Item Env:ANTHROPIC_API_KEY -ErrorAction SilentlyContinue
+$env:ANTHROPIC_BASE_URL = "http://127.0.0.1:$($proxy.Port)"
+Set-ClaudeModelEnv
+# NOTE: not setting ANTHROPIC_AUTH_TOKEN — preserves subscription OAuth flow.
+# NOTE: not unsetting ANTHROPIC_API_KEY — proxy already inherited it; claude
+# uses it if set, else falls back to OAuth.
 
-& claude @Args
-
-foreach ($v in @("ANTHROPIC_BASE_URL","ANTHROPIC_AUTH_TOKEN","ANTHROPIC_MODEL",
-    "ANTHROPIC_DEFAULT_OPUS_MODEL","ANTHROPIC_DEFAULT_SONNET_MODEL",
-    "ANTHROPIC_DEFAULT_HAIKU_MODEL","CLAUDE_CODE_SUBAGENT_MODEL","CLAUDE_CODE_EFFORT_LEVEL")) {
-    Remove-Item "Env:$v" -ErrorAction SilentlyContinue
+try {
+    & claude @Args
+} finally {
+    if ($proxy.Process -and -not $proxy.Process.HasExited) {
+        Stop-Process -Id $proxy.Process.Id -Force -ErrorAction SilentlyContinue
+        Write-Host "  Proxy stopped." -ForegroundColor DarkGray
+    }
+    foreach ($v in @("ANTHROPIC_BASE_URL","ANTHROPIC_DEFAULT_OPUS_MODEL","ANTHROPIC_DEFAULT_SONNET_MODEL",
+        "ANTHROPIC_DEFAULT_HAIKU_MODEL","CLAUDE_CODE_SUBAGENT_MODEL","CLAUDE_CODE_EFFORT_LEVEL")) {
+        Remove-Item "Env:$v" -ErrorAction SilentlyContinue
+    }
 }

--- a/deepclaude.sh
+++ b/deepclaude.sh
@@ -78,10 +78,14 @@ resolve_backend() {
 }
 
 set_model_env() {
-    export ANTHROPIC_DEFAULT_OPUS_MODEL="$RESOLVED_OPUS"
-    export ANTHROPIC_DEFAULT_SONNET_MODEL="$RESOLVED_SONNET"
-    export ANTHROPIC_DEFAULT_HAIKU_MODEL="$RESOLVED_HAIKU"
-    export CLAUDE_CODE_SUBAGENT_MODEL="$RESOLVED_SUBAGENT"
+    # Use canonical Claude model names. Proxy MODEL_REMAP forward-maps to
+    # backend-native IDs (deepseek-v4-pro etc) for non-anthropic modes;
+    # anthropic mode passes through unchanged. This makes mid-session
+    # /anthropic /deepseek /openrouter /fireworks switches all work.
+    export ANTHROPIC_DEFAULT_OPUS_MODEL="claude-opus-4-7"
+    export ANTHROPIC_DEFAULT_SONNET_MODEL="claude-sonnet-4-6"
+    export ANTHROPIC_DEFAULT_HAIKU_MODEL="claude-haiku-4-5"
+    export CLAUDE_CODE_SUBAGENT_MODEL="claude-opus-4-7"
     export CLAUDE_CODE_EFFORT_LEVEL="max"
 }
 
@@ -207,17 +211,55 @@ launch_claude() {
 
     resolve_backend
 
-    echo "  Launching Claude Code via $BACKEND..."
-    echo "  Endpoint: $RESOLVED_URL"
+    # Path 2: cheap backend via proxy (subscription-friendly).
+    # Spawns the model proxy on 3200 (auto-increments if busy).
+    # CRITICAL: do NOT export ANTHROPIC_AUTH_TOKEN. Let the user's
+    # existing auth (subscription OAuth or ANTHROPIC_API_KEY) flow
+    # through. The proxy substitutes the backend's API key per request,
+    # so client auth is irrelevant for non-anthropic /v1/messages calls.
+    echo "  Starting model proxy for $BACKEND..."
+    if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+        echo "  Note: /anthropic mid-session switch unavailable (no ANTHROPIC_API_KEY)."
+        echo "        For anthropic mode, exit and run: deepclaude -b anthropic"
+    fi
+
+    local port_file
+    port_file=$(mktemp)
+    # Tee proxy stdout to /tmp/proxy.log so we can diagnose failures after the fact.
+    node "$SCRIPT_DIR/proxy/start-proxy.js" "$RESOLVED_URL" "$RESOLVED_KEY" 2>&1 | tee /tmp/proxy.log > "$port_file" &
+    PROXY_PID=$!
+
+    local tries=0 proxy_port=""
+    while [[ -z "$proxy_port" ]] && [[ $tries -lt 30 ]]; do
+        sleep 0.2
+        proxy_port=$(grep -oE '^[0-9]+$' "$port_file" 2>/dev/null | head -1 || true)
+        tries=$((tries + 1))
+    done
+    rm -f "$port_file"
+    if [[ -z "$proxy_port" ]]; then
+        echo "ERROR: Proxy failed to start (port not detected)" >&2
+        exit 1
+    fi
+
+    # Switch proxy to chosen backend (legacy startup defaults to anthropic).
+    case "$BACKEND" in
+        ds) curl -sX POST "http://127.0.0.1:$proxy_port/_proxy/mode" -d "backend=deepseek" >/dev/null 2>&1 ;;
+        or) curl -sX POST "http://127.0.0.1:$proxy_port/_proxy/mode" -d "backend=openrouter" >/dev/null 2>&1 ;;
+        fw) curl -sX POST "http://127.0.0.1:$proxy_port/_proxy/mode" -d "backend=fireworks" >/dev/null 2>&1 ;;
+    esac
+
+    echo "  Proxy on :$proxy_port -> $RESOLVED_URL ($BACKEND)"
     echo "  Model: $RESOLVED_OPUS (main) + $RESOLVED_HAIKU (subagents)"
+    echo "  Auth: passthrough (subscription OAuth or ANTHROPIC_API_KEY)"
     echo ""
 
-    export ANTHROPIC_BASE_URL="$RESOLVED_URL"
-    export ANTHROPIC_AUTH_TOKEN="$RESOLVED_KEY"
+    export ANTHROPIC_BASE_URL="http://127.0.0.1:$proxy_port"
     set_model_env
-    unset ANTHROPIC_API_KEY
+    # No export of ANTHROPIC_AUTH_TOKEN. No unset of ANTHROPIC_API_KEY:
+    # claude will use whichever it has; proxy already inherited the env.
 
-    exec claude "$@"
+    # NOT exec: the trap needs to fire on exit to kill the proxy.
+    claude "$@"
 }
 
 launch_remote() {
@@ -234,26 +276,29 @@ launch_remote() {
 
     echo "  Starting model proxy for $BACKEND..."
 
+    if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+        echo "  WARN: ANTHROPIC_API_KEY not set -- /anthropic mid-session switch will 401."
+        echo "        Set with: export ANTHROPIC_API_KEY=sk-ant-..."
+    fi
+
     local port_file
     port_file=$(mktemp)
     node "$SCRIPT_DIR/proxy/start-proxy.js" "$RESOLVED_URL" "$RESOLVED_KEY" > "$port_file" &
     PROXY_PID=$!
 
-    local tries=0
-    while [[ ! -s "$port_file" ]] && [[ $tries -lt 30 ]]; do
+    local tries=0 proxy_port=""
+    while [[ -z "$proxy_port" ]] && [[ $tries -lt 30 ]]; do
         sleep 0.2
+        # Proxy stdout contains banner first, then port number on its own line.
+        # Match a line containing ONLY digits, take first such line.
+        proxy_port=$(grep -oE '^[0-9]+$' "$port_file" 2>/dev/null | head -1 || true)
         tries=$((tries + 1))
     done
-
-    if [[ ! -s "$port_file" ]]; then
-        echo "ERROR: Proxy failed to start" >&2
-        rm -f "$port_file"
+    rm -f "$port_file"
+    if [[ -z "$proxy_port" ]]; then
+        echo "ERROR: Proxy failed to start (port not detected)" >&2
         exit 1
     fi
-
-    local proxy_port
-    proxy_port=$(head -1 "$port_file")
-    rm -f "$port_file"
 
     echo "  Proxy on :$proxy_port -> $RESOLVED_URL"
     echo "  Launching remote control via $BACKEND..."

--- a/proxy/model-proxy.js
+++ b/proxy/model-proxy.js
@@ -122,6 +122,108 @@ function stripUnsignedThinkingBlocks(body) {
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// PER-PATH REQUEST PROCESSORS
+//
+// Each function owns the full request-side transformation for its path. There
+// is NO shared "if (mode === X)" sanitization logic outside these functions —
+// the dispatcher picks one and runs it. Adding a new backend means adding a
+// new processor + wiring it into the dispatcher; existing paths stay untouched.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * PATH A — Anthropic (state.mode === 'anthropic')
+ *
+ * Forwarding to api.anthropic.com.
+ *  • If the conversation history contains turns from a non-Anthropic backend
+ *    (state.hadNonAnthropicSession), strip ALL thinking blocks. Foreign
+ *    backends generate signed-but-invalid blocks that pass the unsigned
+ *    filter and trip Anthropic 400s.
+ *  • Otherwise, strip only UNSIGNED thinking blocks (Anthropic's normal
+ *    requirement — its own signed blocks are valid and must be passed back).
+ *  • No model remap.
+ */
+function processAnthropicRequest(body, state, reqId) {
+    try {
+        const parsed = JSON.parse(body);
+        if (state.hadNonAnthropicSession) {
+            stripAllThinkingBlocks(parsed);
+        } else {
+            stripUnsignedThinkingBlocks(parsed);
+        }
+        return Buffer.from(JSON.stringify(parsed));
+    } catch {
+        // Body wasn't JSON — pass through unchanged.
+        return body;
+    }
+}
+
+/**
+ * PATH B — DeepSeek (state.mode === 'deepseek')
+ *
+ * Forwarding to DeepSeek's Anthropic-compat endpoint.
+ *  • Apply MODEL_REMAP['deepseek'] to the `model` field.
+ *  • DO NOT strip thinking blocks. DeepSeek's endpoint REQUIRES prior
+ *    thinking blocks to be passed back when the request includes
+ *    thinking-mode parameters; absence returns 400 with
+ *    "content[].thinking ... must be passed back".
+ *  • The JSONL Claude Code persists will reflect real DeepSeek content
+ *    (foreign-signed thinking, deepseek-v4-pro model name). That is by
+ *    design — a DeepSeek session is a DeepSeek session.
+ */
+function processDeepseekRequest(body, state, reqId) {
+    try {
+        const parsed = JSON.parse(body);
+        const remap = MODEL_REMAP.deepseek;
+        if (remap && parsed.model && remap[parsed.model]) {
+            const mapped = remap[parsed.model];
+            console.log(`[MODEL-PROXY] #${reqId} model remap: ${parsed.model} → ${mapped}`);
+            parsed.model = mapped;
+            return Buffer.from(JSON.stringify(parsed));
+        }
+        return body;
+    } catch {
+        // Body wasn't JSON — pass through unchanged.
+        return body;
+    }
+}
+
+/**
+ * PATH C — Other non-Anthropic backends (openrouter, fireworks, _single)
+ *
+ * Forwarding to the configured backend.
+ *  • Apply MODEL_REMAP[mode] if defined for this mode.
+ *  • Strip ALL thinking blocks. These backends are assumed to reject
+ *    foreign-signed thinking blocks (the original deepclaude assumption).
+ *    We have NOT validated whether any of them require continuity like
+ *    DeepSeek does. If a future backend turns out to need pass-through,
+ *    promote it to its own dedicated path (do not weaken this one).
+ */
+function processOtherBackendRequest(body, state, reqId) {
+    try {
+        const parsed = JSON.parse(body);
+        let changed = false;
+
+        const remap = MODEL_REMAP[state.mode];
+        if (remap && parsed.model && remap[parsed.model]) {
+            const mapped = remap[parsed.model];
+            console.log(`[MODEL-PROXY] #${reqId} model remap: ${parsed.model} → ${mapped}`);
+            parsed.model = mapped;
+            changed = true;
+        }
+
+        // Strip foreign thinking blocks before forwarding.
+        const before = JSON.stringify(parsed.messages || null);
+        stripAllThinkingBlocks(parsed);
+        if (JSON.stringify(parsed.messages || null) !== before) changed = true;
+
+        return changed ? Buffer.from(JSON.stringify(parsed)) : body;
+    } catch {
+        // Body wasn't JSON — pass through unchanged.
+        return body;
+    }
+}
+
 export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends, defaultMode }) {
     return new Promise((resolve, reject) => {
         const initialTarget = new URL(targetUrl);
@@ -270,9 +372,20 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
                 return;
             }
 
-            // In anthropic mode, everything passes through transparently
+            // ─────────────────────────────────────────────────────────────
+            // Decide ONCE which path this request takes. After this point,
+            // no shared sanitization branches exist — each path is handled
+            // by its own processor function.
+            // ─────────────────────────────────────────────────────────────
             const isAnthropicMode = state.mode === 'anthropic';
+            // A "model call" is a /v1/messages request to a NON-Anthropic
+            // backend (i.e. PATH B or PATH C). Anthropic-mode /v1/messages
+            // calls are still proxied to api.anthropic.com but flagged
+            // separately because they use a different upstream (the
+            // ANTHROPIC_FALLBACK target, not state.target) and skip the
+            // backend auth header / model remap entirely.
             const isModelCall = !isAnthropicMode && MODEL_PATHS.includes(urlPath);
+            const isAnthropicModelCall = isAnthropicMode && MODEL_PATHS.includes(urlPath);
             const dest = isModelCall ? state.target : new URL(ANTHROPIC_FALLBACK);
 
             // Build upstream path. target.pathname may overlap with
@@ -315,42 +428,28 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
             clientReq.on('end', () => {
                 let body = Buffer.concat(chunks);
 
-                // Remap Anthropic model names to backend-specific names
-                if (isModelCall && MODEL_REMAP[state.mode]) {
-                    try {
-                        const parsed = JSON.parse(body);
-                        const mapped = MODEL_REMAP[state.mode][parsed.model];
-                        if (mapped) {
-                            console.log(`[MODEL-PROXY] #${reqId} model remap: ${parsed.model} → ${mapped}`);
-                            parsed.model = mapped;
-                            body = Buffer.from(JSON.stringify(parsed));
-                        }
-                    } catch { /* not JSON or parse error, pass through */ }
-                }
-
-                // Strip thinking blocks before forwarding.
-                // Non-Anthropic: strip ALL blocks — backends reject thinking blocks
-                // they didn't generate, even unsigned ones.
-                // Anthropic after a non-Anthropic session: also strip ALL, because
-                // foreign backends generate signed-but-invalid thinking blocks that
-                // stripUnsignedThinkingBlocks passes through, causing Anthropic 400s.
-                if (isAnthropicMode && MODEL_PATHS.includes(urlPath)) {
-                    try {
-                        const parsed = JSON.parse(body);
-                        if (state.hadNonAnthropicSession) {
-                            stripAllThinkingBlocks(parsed);
-                        } else {
-                            stripUnsignedThinkingBlocks(parsed);
-                        }
-                        body = Buffer.from(JSON.stringify(parsed));
-                    } catch { /* pass through */ }
-                }
-                if (isModelCall) {
-                    try {
-                        const parsed = JSON.parse(body);
-                        stripAllThinkingBlocks(parsed);
-                        body = Buffer.from(JSON.stringify(parsed));
-                    } catch { /* pass through */ }
+                // ─────────────────────────────────────────────────────────
+                // Dispatch to ONE per-path request processor. Each processor
+                // owns all sanitization for its path — no shared logic.
+                //
+                //   PATH A — Anthropic         : strip thinking (signed?
+                //                                depends on prior session),
+                //                                no model remap.
+                //   PATH B — DeepSeek          : remap model only,
+                //                                NEVER strip thinking
+                //                                (endpoint requires it).
+                //   PATH C — Other non-Anthr.  : remap model + strip ALL
+                //                                thinking blocks.
+                //   (non-/v1/messages traffic in non-Anthropic mode and all
+                //    non-/v1/messages traffic in Anthropic mode bypasses
+                //    request-body processing entirely — pure passthrough.)
+                // ─────────────────────────────────────────────────────────
+                if (isAnthropicModelCall) {
+                    body = processAnthropicRequest(body, state, reqId);
+                } else if (isModelCall && state.mode === 'deepseek') {
+                    body = processDeepseekRequest(body, state, reqId);
+                } else if (isModelCall) {
+                    body = processOtherBackendRequest(body, state, reqId);
                 }
 
                 const opts = {
@@ -379,6 +478,12 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
                     const ct = proxyRes.headers['content-type'] || '';
                     const isSSE = ct.includes('text/event-stream');
 
+                    // Response path: pass-through for ALL paths. UsageNormalizer
+                    // for SSE (Claude-Code crash guard); normalizeJsonBody for
+                    // non-streaming JSON (same guard). No model un-mapping. No
+                    // thinking-block stripping. The JSONL Claude Code persists
+                    // for a backend session reflects that backend's actual
+                    // output — that's by design.
                     if (isModelCall && isSSE) {
                         clientRes.writeHead(proxyRes.statusCode, proxyRes.headers);
                         const norm = new UsageNormalizer((inp, out) => recordUsage(state.mode, inp, out));

--- a/proxy/model-proxy.js
+++ b/proxy/model-proxy.js
@@ -368,6 +368,14 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
                         console.log(`[MODEL-PROXY] #${reqId} TTFB ${ttfb}ms (status ${proxyRes.statusCode})`);
                     }
 
+                    // Backend can drop the connection mid-stream (own timeout,
+                    // restart, network glitch). Without this handler, Node's
+                    // EventEmitter throws 'Unhandled error' and crashes the proxy.
+                    proxyRes.on('error', (err) => {
+                        console.error(`[MODEL-PROXY] #${reqId} proxyRes error: ${err.message}`);
+                        if (!clientRes.destroyed) clientRes.destroy();
+                    });
+
                     const ct = proxyRes.headers['content-type'] || '';
                     const isSSE = ct.includes('text/event-stream');
 
@@ -414,9 +422,15 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
                     const elapsed = ((Date.now() - t0) / 1000).toFixed(1);
                     console.error(`[MODEL-PROXY] #${reqId} ERROR after ${elapsed}s: ${err.message}`);
                     if (!clientRes.headersSent) {
+                        // Headers not sent — safe to write a clean 502 JSON body.
                         clientRes.writeHead(502, { 'content-type': 'application/json' });
+                        clientRes.end(JSON.stringify({ error: { message: 'Upstream connection error' } }));
+                    } else if (!clientRes.destroyed) {
+                        // Headers already sent — likely SSE streaming. Appending
+                        // JSON would corrupt the stream and crash Claude Code's
+                        // SSE parser. Close the socket cleanly instead.
+                        clientRes.destroy();
                     }
-                    clientRes.end(JSON.stringify({ error: { message: 'Upstream connection error' } }));
                 });
 
                 proxyReq.end(body);

--- a/proxy/model-proxy.js
+++ b/proxy/model-proxy.js
@@ -123,6 +123,41 @@ function stripUnsignedThinkingBlocks(body) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// SIGNATURE-SHAPE CLASSIFIERS (stateless heuristic).
+//
+// Anthropic thinking signatures are base64-encoded crypto signatures, typically
+// 80+ characters. DeepSeek thinking signatures observed in the wild are shorter
+// (hex-string or UUID-shape, well under 80 chars). The proxy uses these
+// heuristics to decide, per request, which thinking blocks to forward to which
+// destination — entirely from the request body, with no session state.
+// ─────────────────────────────────────────────────────────────────────────────
+function isLikelyAnthropicSignature(sig) {
+    return typeof sig === 'string' && sig.length >= 80;
+}
+function isLikelyDeepseekSignature(sig) {
+    return typeof sig === 'string' && sig.length > 0 && sig.length < 80;
+}
+
+/**
+ * Walk parsed.messages[] and filter thinking blocks by a per-block predicate.
+ * Returns { kept, stripped } counts. Mutates parsed in place.
+ */
+function filterThinkingBlocks(parsed, keepPredicate) {
+    let kept = 0, stripped = 0;
+    if (!parsed?.messages) return { kept, stripped };
+    for (const msg of parsed.messages) {
+        if (!Array.isArray(msg.content)) continue;
+        msg.content = msg.content.filter(block => {
+            if (block.type !== 'thinking') return true;
+            if (keepPredicate(block)) { kept++; return true; }
+            stripped++;
+            return false;
+        });
+    }
+    return { kept, stripped };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // PER-PATH REQUEST PROCESSORS
 //
 // Each function owns the full request-side transformation for its path. There
@@ -134,22 +169,60 @@ function stripUnsignedThinkingBlocks(body) {
 /**
  * PATH A — Anthropic (state.mode === 'anthropic')
  *
- * Forwarding to api.anthropic.com.
- *  • If the conversation history contains turns from a non-Anthropic backend
- *    (state.hadNonAnthropicSession), strip ALL thinking blocks. Foreign
- *    backends generate signed-but-invalid blocks that pass the unsigned
- *    filter and trip Anthropic 400s.
- *  • Otherwise, strip only UNSIGNED thinking blocks (Anthropic's normal
- *    requirement — its own signed blocks are valid and must be passed back).
+ * Forwarding to api.anthropic.com. Stateless: classifies thinking blocks by
+ * signature shape per request — no session flags consulted.
+ *  • Strip context-tier suffix ("claude-opus-4-7[1m]" → "claude-opus-4-7").
+ *  • CLEAN-BREAK on mixed-sig histories: Anthropic's API requires signed
+ *    thinking blocks to round-trip EXACTLY within a thinking-budget chain.
+ *    A partial strip (drop foreign, keep same-sig) leaves gaps in the kept
+ *    sequence — the surviving anthropic-sig blocks reference cryptographic
+ *    state that the API expects to be contiguous, and the missing turns
+ *    invalidate the chain. So if ANY foreign-sig block is detected, drop ALL
+ *    thinking blocks. Anthropic treats the resulting messages[] as a fresh
+ *    thinking conversation — no continuity assumed. Subsequent same-mode
+ *    turns recover thinking once new anthropic-sig blocks accumulate.
+ *  • If no foreign-sig blocks present (all anthropic-shaped or none), keep
+ *    them as-is — that's a legitimate same-backend continuation.
+ *  • parsed.thinking is left intact — Anthropic accepts thinking-mode without
+ *    prior thinking blocks on the first turn (or after a clean break).
  *  • No model remap.
  */
 function processAnthropicRequest(body, state, reqId) {
     try {
         const parsed = JSON.parse(body);
-        if (state.hadNonAnthropicSession) {
-            stripAllThinkingBlocks(parsed);
+        if (parsed.model && /\[\d+[mk]\]$/i.test(parsed.model)) {
+            const original = parsed.model;
+            parsed.model = parsed.model.replace(/\[\d+[mk]\]$/i, '');
+            console.log(`[MODEL-PROXY] #${reqId} stripped tier suffix: ${original} -> ${parsed.model}`);
+        }
+        // First pass: detect FOREIGN-SIG blocks (deepseek-shaped). Unsigned
+        // thinking is NOT a continuity-breaker for Anthropic — it's just a
+        // malformed block that gets stripped without affecting the chain.
+        // Only deepseek-shaped sigs in a kept anthropic-sig chain break it.
+        let foreignCount = 0;
+        if (parsed?.messages) {
+            for (const msg of parsed.messages) {
+                if (!Array.isArray(msg.content)) continue;
+                for (const block of msg.content) {
+                    if (block.type === 'thinking' && isLikelyDeepseekSignature(block.signature)) {
+                        foreignCount++;
+                    }
+                }
+            }
+        }
+        if (foreignCount > 0) {
+            // Clean break: strip ALL thinking blocks (anth-sig + foreign + unsigned)
+            const r = filterThinkingBlocks(parsed, () => false);
+            console.log(`[MODEL-PROXY] #${reqId} clean-break strip: removed all ${r.stripped} thinking blocks (${foreignCount} foreign-sig present) — Anthropic continuity unrecoverable`);
         } else {
-            stripUnsignedThinkingBlocks(parsed);
+            // No foreign-sig blocks; keep anthropic-sig, drop unsigned (Anthropic rejects unsigned).
+            const { kept, stripped } = filterThinkingBlocks(
+                parsed,
+                block => isLikelyAnthropicSignature(block.signature)
+            );
+            if (stripped > 0) {
+                console.log(`[MODEL-PROXY] #${reqId} stripped ${stripped} unsigned thinking blocks (kept ${kept} signed)`);
+            }
         }
         return Buffer.from(JSON.stringify(parsed));
     } catch {
@@ -161,27 +234,66 @@ function processAnthropicRequest(body, state, reqId) {
 /**
  * PATH B — DeepSeek (state.mode === 'deepseek')
  *
- * Forwarding to DeepSeek's Anthropic-compat endpoint.
+ * Forwarding to DeepSeek's Anthropic-compat endpoint. Stateless: classifies
+ * thinking blocks by signature shape per request — no session flags consulted.
  *  • Apply MODEL_REMAP['deepseek'] to the `model` field.
- *  • DO NOT strip thinking blocks. DeepSeek's endpoint REQUIRES prior
- *    thinking blocks to be passed back when the request includes
- *    thinking-mode parameters; absence returns 400 with
- *    "content[].thinking ... must be passed back".
- *  • The JSONL Claude Code persists will reflect real DeepSeek content
- *    (foreign-signed thinking, deepseek-v4-pro model name). That is by
- *    design — a DeepSeek session is a DeepSeek session.
+ *  • CLEAN-BREAK on mixed-sig histories: DeepSeek validates per-turn thinking
+ *    continuity. A partial strip (drop anth-sig, keep ds-sig) leaves gaps in
+ *    the kept ds-sig sequence — DeepSeek then rejects with 400 even when
+ *    parsed.thinking is removed, because the kept blocks reference state from
+ *    turns that no longer exist. So when ANY foreign-sig (anthropic-shaped)
+ *    block is detected, drop ALL thinking blocks AND drop parsed.thinking.
+ *    DeepSeek treats the resulting messages[] as a fresh conversation —
+ *    continuity is sacrificed for the cross-mode turn but recovers naturally
+ *    on subsequent same-mode turns once new ds-sig blocks accumulate.
+ *  • If no strip is needed (all surviving blocks are DeepSeek-shaped or none
+ *    existed), KEEP parsed.thinking so DeepSeek continues its reasoning.
  */
 function processDeepseekRequest(body, state, reqId) {
     try {
         const parsed = JSON.parse(body);
+        // First pass: detect foreign-sig blocks
+        const probe = filterThinkingBlocks(
+            JSON.parse(JSON.stringify(parsed)),
+            block => isLikelyDeepseekSignature(block.signature)
+        );
+        let kept = 0, stripped = 0;
+        if (probe.stripped > 0) {
+            // Clean break: strip ALL thinking blocks (kept + foreign)
+            const r = filterThinkingBlocks(parsed, () => false);
+            stripped = r.stripped;
+            console.log(`[MODEL-PROXY] #${reqId} clean-break strip: removed all ${stripped} thinking blocks (${probe.stripped} foreign-sig + ${probe.kept} same-sig) — DeepSeek continuity unrecoverable`);
+            if (parsed.thinking !== undefined) {
+                const shape = JSON.stringify(parsed.thinking);
+                delete parsed.thinking;
+                console.log(`[MODEL-PROXY] #${reqId} dropped parsed.thinking (clean break, was: ${shape.length > 100 ? shape.slice(0, 100) + '...' : shape})`);
+            }
+        } else {
+            // No foreign-sig blocks; keep deepseek-sig as-is
+            const r = filterThinkingBlocks(parsed, block => isLikelyDeepseekSignature(block.signature));
+            kept = r.kept;
+        }
+        // Post-strip invariant: if any assistant turn lacks a thinking block,
+        // DeepSeek cannot maintain thinking continuity. Explicitly disable
+        // thinking-mode and remove output_config (DS rejects disabled+effort combo).
+        const anyGap = parsed.messages?.some(m =>
+            m.role === 'assistant' &&
+            Array.isArray(m.content) &&
+            m.content.length > 0 &&
+            !m.content.some(b => b.type === 'thinking')
+        );
+        if (anyGap) {
+            parsed.thinking = { type: 'disabled' };
+            delete parsed.output_config;
+            console.log(`[MODEL-PROXY] #${reqId} set thinking=disabled: assistant turn(s) missing thinking block`);
+        }
         const remap = MODEL_REMAP.deepseek;
         if (remap && parsed.model && remap[parsed.model]) {
             const mapped = remap[parsed.model];
             console.log(`[MODEL-PROXY] #${reqId} model remap: ${parsed.model} → ${mapped}`);
             parsed.model = mapped;
-            return Buffer.from(JSON.stringify(parsed));
         }
-        return body;
+        return Buffer.from(JSON.stringify(parsed));
     } catch {
         // Body wasn't JSON — pass through unchanged.
         return body;
@@ -212,10 +324,18 @@ function processOtherBackendRequest(body, state, reqId) {
             changed = true;
         }
 
-        // Strip foreign thinking blocks before forwarding.
+        // Stateless conservative strip: these backends are unvalidated. Drop
+        // ALL thinking blocks and parsed.thinking, regardless of signature.
         const before = JSON.stringify(parsed.messages || null);
         stripAllThinkingBlocks(parsed);
-        if (JSON.stringify(parsed.messages || null) !== before) changed = true;
+        if (JSON.stringify(parsed.messages || null) !== before) {
+            changed = true;
+            console.log(`[MODEL-PROXY] #${reqId} stripped all thinking blocks (PATH C conservative)`);
+        }
+        if (parsed.thinking) {
+            delete parsed.thinking;
+            changed = true;
+        }
 
         return changed ? Buffer.from(JSON.stringify(parsed)) : body;
     } catch {
@@ -254,7 +374,6 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
             // Anthropic uses x-api-key (NOT Bearer); only OpenRouter/Fireworks
             // use Bearer. So if booting in anthropic mode, useBearer is false.
             useBearer: startBackend ? startBackend.useBearer : (anthropicBootKey ? false : initialBearer),
-            hadNonAnthropicSession: !!startBackend,
         };
 
         let reqCount = 0;
@@ -305,6 +424,15 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
 
         function switchMode(name) {
             if (name === 'anthropic') {
+                // Strict path isolation: refuse anthropic-mode switch when no
+                // ANTHROPIC_API_KEY is configured. Subscription OAuth bearers
+                // are rejected by api.anthropic.com ("invalid x-api-key"); the
+                // bridge protocol (which subscription auth needs) is not
+                // implemented in this proxy. Force users to exit and relaunch
+                // in plain claude (no proxy) for a real anthropic session.
+                if (!anthropicApiKey) {
+                    return { error: 'anthropic mode unavailable: no ANTHROPIC_API_KEY set. To use Anthropic, exit this session and run: deepclaude -b anthropic (or set ANTHROPIC_API_KEY env and relaunch).' };
+                }
                 const prev = state.mode;
                 state.mode = 'anthropic';
                 state.target = new URL(ANTHROPIC_FALLBACK);
@@ -323,7 +451,6 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
             state.target = b.target;
             state.apiKey = b.apiKey;
             state.useBearer = b.useBearer;
-            state.hadNonAnthropicSession = true;
             return { mode: name, previous: prev };
         }
 
@@ -430,6 +557,11 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
 
             const headers = { ...clientReq.headers, host: dest.host };
             delete headers['content-length'];
+            // Strip accept-encoding so upstream sends plain text. The
+            // UsageNormalizer Transform stream calls .toString() on incoming
+            // chunks, which corrupts gzip-encoded bytes. Forcing identity
+            // encoding upstream keeps the stream text-clean.
+            delete headers['accept-encoding'];
 
             // Auth substitution per active path. If state.apiKey is set
             // (because the user configured DEEPSEEK_API_KEY / ANTHROPIC_API_KEY
@@ -514,14 +646,14 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
                     // thinking-block stripping. The JSONL Claude Code persists
                     // for a backend session reflects that backend's actual
                     // output — that's by design.
-                    if (isModelCall && isSSE) {
+                    if ((isModelCall || isAnthropicModelCall) && isSSE) {
                         clientRes.writeHead(proxyRes.statusCode, proxyRes.headers);
                         const norm = new UsageNormalizer((inp, out) => recordUsage(state.mode, inp, out));
                         proxyRes.pipe(norm).pipe(clientRes);
                         proxyRes.on('end', () => {
                             console.log(`[MODEL-PROXY] #${reqId} done in ${((Date.now() - t0) / 1000).toFixed(1)}s (${norm._inputTokens}in/${norm._outputTokens}out)`);
                         });
-                    } else if (isModelCall && ct.includes('application/json')) {
+                    } else if ((isModelCall || isAnthropicModelCall) && ct.includes('application/json')) {
                         const respChunks = [];
                         proxyRes.on('data', c => respChunks.push(c));
                         proxyRes.on('end', () => {

--- a/proxy/model-proxy.js
+++ b/proxy/model-proxy.js
@@ -242,11 +242,18 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
         const initialName = defaultMode || (backends ? 'anthropic' : null);
         const startBackend = initialName && initialName !== 'anthropic' && allBackends[initialName];
 
+        // If the proxy boots in anthropic mode AND ANTHROPIC_API_KEY is set in
+        // the env, populate apiKey from there so the auth-substitution path
+        // works from the first request without needing a /_proxy/mode flip.
+        const anthropicBootKey = (initialName === 'anthropic' && process.env.ANTHROPIC_API_KEY) || null;
+
         const state = {
             mode: initialName || '_single',
             target: startBackend ? startBackend.target : initialTarget,
-            apiKey: startBackend ? startBackend.apiKey : apiKey,
-            useBearer: startBackend ? startBackend.useBearer : initialBearer,
+            apiKey: startBackend ? startBackend.apiKey : (anthropicBootKey || apiKey),
+            // Anthropic uses x-api-key (NOT Bearer); only OpenRouter/Fireworks
+            // use Bearer. So if booting in anthropic mode, useBearer is false.
+            useBearer: startBackend ? startBackend.useBearer : (anthropicBootKey ? false : initialBearer),
             hadNonAnthropicSession: !!startBackend,
         };
 
@@ -288,12 +295,23 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
             };
         }
 
+        // Anthropic-side auth: optional. If ANTHROPIC_API_KEY is set in the
+        // proxy's process env, the proxy will INJECT it as the auth header on
+        // requests in anthropic mode (same substitution as for non-anthropic
+        // backends, completing the path-isolation story for auth too). If
+        // unset, the proxy passes the client's existing auth header through
+        // unchanged (transparent passthrough — useful for OAuth bridge).
+        const anthropicApiKey = process.env.ANTHROPIC_API_KEY || null;
+
         function switchMode(name) {
             if (name === 'anthropic') {
                 const prev = state.mode;
                 state.mode = 'anthropic';
                 state.target = new URL(ANTHROPIC_FALLBACK);
-                state.apiKey = null;
+                state.apiKey = anthropicApiKey;
+                // Anthropic auth uses the x-api-key header (NOT Bearer).
+                // Bearer is reserved for OAuth bridge sessions, which are
+                // never set up via ANTHROPIC_API_KEY env var.
                 state.useBearer = false;
                 return { mode: 'anthropic', previous: prev };
             }
@@ -413,7 +431,19 @@ export function startModelProxy({ targetUrl, apiKey, startPort = 3200, backends,
             const headers = { ...clientReq.headers, host: dest.host };
             delete headers['content-length'];
 
-            if (isModelCall) {
+            // Auth substitution per active path. If state.apiKey is set
+            // (because the user configured DEEPSEEK_API_KEY / ANTHROPIC_API_KEY
+            // / OPENROUTER_API_KEY / FIREWORKS_API_KEY in the proxy's env),
+            // strip the client's auth headers and inject the path-appropriate
+            // key. This makes mode switching seamless: Claude Code's
+            // ANTHROPIC_AUTH_TOKEN can be any value (even a wrong one); the
+            // proxy substitutes the right key per mode.
+            //
+            // If state.apiKey is null (typically anthropic mode without
+            // ANTHROPIC_API_KEY set), the client's auth header is forwarded
+            // unchanged — useful for OAuth bridge mode where Claude Code
+            // already holds a valid Anthropic session token.
+            if (MODEL_PATHS.includes(urlPath) && state.apiKey) {
                 delete headers['authorization'];
                 delete headers['x-api-key'];
                 if (state.useBearer) {


### PR DESCRIPTION
## Summary

Fixes the `content[].thinking ... must be passed back to the API` 400-error class that previously fired on every `anthropic → deepseek` round-trip in mid-session switching. Adds subscription-friendly wrapper mode so Claude Max users can route cheap-backend traffic through the proxy without giving up their subscription auth.

Validated end-to-end on a Linux GCE VM:
- 33/33 unit tests pass (cross-switch + deferred-set + stateless suites)
- 28/28 live TUI steps clean across 6 cross-mode round-trips, zero 400 errors

## Commits (4 ahead of main)

- `8543afc` fix: handle proxyRes mid-stream errors + SSE-safe error response
- `def324e` feat: two strictly isolated request paths for model-call dispatch (PATH A anthropic, B deepseek, C other — no shared sanitization branches)
- `a6f5ff6` feat: anthropic mode auth substitution via `ANTHROPIC_API_KEY` env var (proxy substitutes the right backend key per request, so client auth is irrelevant)
- `a7814ba` fix: **the core fix** — stateless thinking-block classification + post-strip invariant + subscription-friendly wrapper

## Key design decisions

**1. Stateless body normalization** (replaces the prior `state.hadXSession` flags). Each per-path processor inspects `parsed.messages` per request and classifies thinking blocks by signature shape. The proxy is a stateless router; trying to track cross-request flags in it diverged from `messages[]` whenever the proxy restarted, was resumed, or saw a turn from the bridge.

**2. Post-strip invariant** (`processDeepseekRequest`):
> If any assistant turn lacks a thinking block, DeepSeek cannot maintain thinking continuity. Set `parsed.thinking = {type: 'disabled'}` and remove `parsed.output_config` (DS rejects `disabled + reasoning_effort` combo).

This catches the case where Anthropic's `adaptive` thinking-mode emitted a tool-use turn without a thinking block, then conversation comes back to DeepSeek which enforces per-turn continuity (per DeepSeek docs).

**3. Subscription-friendly wrapper path 2**: stop forcing `ANTHROPIC_AUTH_TOKEN` to the backend's API key. Let the user's existing auth (subscription OAuth or `ANTHROPIC_API_KEY`) flow through; the proxy substitutes the right backend key per request.

**4. Wrapper port-extraction fix**: longstanding bug where `head -1`/`Select-Object -First 1` grabbed the proxy banner instead of the port number. Now matches numeric-only line.

## Test plan

- [x] Unit tests: 15 + 4 + 14 = 33 assertions across cross-switch, deferred-set, stateless suites
- [x] Live TUI: 28-step comprehensive scenario with 6 cross-mode round-trips, 4 backends (DS / Anthropic), tool-use chains, rapid-flips, long-history accumulation
- [x] Math correctness verified end-to-end (363468×2535=921,391,380 etc.)
- [x] Both API-key and Claude Max subscription auth modes
- [x] PowerShell + Bash wrappers in lockstep

## Files changed in latest commit

- `proxy/model-proxy.js` (stateless redesign, +178/-46)
- `deepclaude.sh` (subscription-friendly path 2, port-fix, auto-mode-set, +66/-19)
- `deepclaude.ps1` (parity with `.sh`, +153/-74)
- `README.md` (env-vars table, mid-session prerequisites, +30/-6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)